### PR TITLE
RES_USE_DNSSEC must come after res_init()

### DIFF
--- a/libopendmarc/opendmarc_dns.c
+++ b/libopendmarc/opendmarc_dns.c
@@ -202,18 +202,17 @@ dmarc_dns_get_record(char *domain, int *reply, char *got_txtbuf, size_t got_txtl
 		++bp;
 
 #ifdef HAVE_RES_NINIT   
-	memset(&resp, '\0', sizeof resp);
-	resp.options |= RES_DEFAULT;
-#if defined RES_USE_DNSSEC
+	res_ninit(&resp);
+#ifdef RES_USE_DNSSEC
 	resp.options |= RES_USE_DNSSEC;
 #endif
-	res_ninit(&resp);
 	(void) opendmarc_policy_library_dns_hook(&resp.nscount,
                                                  &resp.nsaddr_list);
 	answer_len = res_nquery(&resp, bp, C_IN, T_TXT, answer_buf, sizeof answer_buf);
 	res_nclose(&resp);
 #else /* HAVE_RES_NINIT */
-#if defined RES_USE_DNSSEC
+	res_init();
+#ifdef RES_USE_DNSSEC
 	_res.options |= RES_USE_DNSSEC;
 #endif
 	(void) opendmarc_policy_library_dns_hook(&_res.nscount,


### PR DESCRIPTION
The way it is now, the RES_USE_DNSSEC option has no effect: glibc doesn't set the DO bit. res_query() calls res_init() implicitly when it hasn't been called already.