### PR TITLE
Feature/update readmes for arc

### DIFF
--- a/opendmarc/README
+++ b/opendmarc/README
@@ -49,9 +49,9 @@ CONFIGURING OPENDMARC
 
 	    INPUT_MAIL_FILTER(`opendmarc', `S=inet:8893@localhost')
 
-        Note that this must come after filters that do DKIM and SPF evaluation,
-        as this filter relies on the addition of authentication results data
-        to the header by upstream filters.
+        Note that this must come after filters that do DKIM, SPF, and ARC
+        evaluation, as this filter relies on the addition of authentication
+        results data to the header by upstream filters.
 
     (c) Rebuild your sendmail.cf in the usual way
 
@@ -174,6 +174,34 @@ their encodings, but there are only a few of them:
 			16 = reject
 			17 = quarantine
 			18 = none
+
+ARC Evaluation by OpenDMARC
+===========================
+
+Mailing lists and some forwarders can break authentication information on
+messages, resulting in false positive DMARC failures. ARC allows breaking
+intermediaries to encapsulate the authentication information they saw, so that
+a downstream MTA can more properly evaluate the message and deliver around an
+otherwise false positive result.
+
+OpenDMARC uses ARC information to deliver a message around a failure in a very
+specific and limited fashion. OpenDMARC does not evaluate the ARC status of a
+message, it relies on other ARC-aware software (such as OpenARC) to make a
+determination about the validity of any ARC information on the message, and
+stamp those results in the Authentication-Results for the local
+TrustedAuthservID. At a high level (explained further below), OpenDMARC then
+reviews those trusted results, makes a determination if it trusts the domains
+which sealed the chain, and decides whether or not to override the original
+message disposition. The results of this evaluation are then recorded and
+returned in the local_policy comment to the sending domain owner.
+
+OpenDMARC makes its limited determination about delivering around a DMARC
+failure in the following way: When DMARC fails, and there is one and only one
+arc status in the Authentication-Results for the local TrustedAuthservID, and
+that arc status is “pass”, and all sealers are on the DomainWhitelist, then
+the message will be delivered instead of being subject to the DMARC policy of
+the sending domain.
+
 
 SUPPORT
 =======

--- a/opendmarc/README
+++ b/opendmarc/README
@@ -178,27 +178,27 @@ their encodings, but there are only a few of them:
 ARC Evaluation by OpenDMARC
 ===========================
 
-Mailing lists and some forwarders can break authentication information on
-messages, resulting in false positive DMARC failures. ARC allows breaking
+Mailing lists and some forwarders can break authentication of valid
+messages, resulting in false positive DMARC failures.  ARC allows such
 intermediaries to encapsulate the authentication information they saw, so that
 a downstream MTA can more properly evaluate the message and deliver around an
 otherwise false positive result.
 
 OpenDMARC uses ARC information to deliver a message around a failure in a very
-specific and limited fashion. OpenDMARC does not evaluate the ARC status of a
-message, it relies on other ARC-aware software (such as OpenARC) to make a
+specific and limited fashion.  OpenDMARC does not evaluate the ARC status of a
+message; it relies on other ARC-aware software (such as OpenARC) to make a
 determination about the validity of any ARC information on the message, and
-stamp those results in the Authentication-Results for the local
-TrustedAuthservID. At a high level (explained further below), OpenDMARC then
-reviews those trusted results, makes a determination if it trusts the domains
-which sealed the chain, and decides whether or not to override the original
-message disposition. The results of this evaluation are then recorded and
-returned in the local_policy comment to the sending domain owner.
+attach those results in the Authentication-Results for the local
+TrustedAuthservID.  At a high level (explained further below), OpenDMARC then
+reviews those trusted results, makes a determination as to whether it trusts
+the domains that sealed the chain, and decides whether to override the
+original message disposition. The results of this evaluation are then recorded
+and returned in the "local_policy" comment to the sending domain owner.
 
 OpenDMARC makes its limited determination about delivering around a DMARC
 failure in the following way: When DMARC fails, and there is one and only one
-arc status in the Authentication-Results for the local TrustedAuthservID, and
-that arc status is “pass”, and all sealers are on the DomainWhitelist, then
+ARC status in the Authentication-Results for the local TrustedAuthservID, and
+that ARC status is “pass”, and all sealers are on the DomainWhitelist, then
 the message will be delivered instead of being subject to the DMARC policy of
 the sending domain.
 


### PR DESCRIPTION
Updates opendmarc milter README with information on milter ordering and how and when OpenDMARC evaluates an ARC chain and uses its results to modify message disposition.