### PR TITLE
Add support for reporting AAR client-ip for first hop recipient

### DIFF
--- a/db/schema.mysql
+++ b/db/schema.mysql
@@ -16,6 +16,7 @@ CREATE TABLE IF NOT EXISTS domains (
 	UNIQUE KEY(name)
 );
 
+-- A table for logging encountered ARC selectors
 CREATE TABLE IF NOT EXISTS selectors (
 	id INT NOT NULL AUTO_INCREMENT,
 	domain INT NOT NULL,
@@ -27,6 +28,19 @@ CREATE TABLE IF NOT EXISTS selectors (
 	UNIQUE KEY(name, domain)
 );
 
+-- A table for logging ARC-Authentication-Results information
+CREATE TABLE IF NOT EXISTS arcauthresults (
+	id INT NOT NULL AUTO_INCREMENT,
+	message INT UNSIGNED NOT NULL,
+	instance INT UNSIGNED NOT NULL,
+	arc_client_addr VARCHAR(64) NOT NULL DEFAULT '',
+
+	PRIMARY KEY(id),
+	KEY(message),
+	UNIQUE KEY(message, instance)
+);
+
+-- A table for logging ARC-Seal information
 CREATE TABLE IF NOT EXISTS arcseals (
 	id INT NOT NULL AUTO_INCREMENT,
 	message INT UNSIGNED NOT NULL,
@@ -69,7 +83,7 @@ CREATE TABLE IF NOT EXISTS reporters (
 	UNIQUE KEY(name)
 );
 
--- A table for IP addresses
+-- A table for connecting client IP addresses
 CREATE TABLE IF NOT EXISTS ipaddr (
 	id INT NOT NULL AUTO_INCREMENT,
 	addr VARCHAR(64) NOT NULL,

--- a/opendmarc/Makefile.am
+++ b/opendmarc/Makefile.am
@@ -12,6 +12,7 @@ sbin_PROGRAMS = opendmarc opendmarc-check
 
 opendmarc_SOURCES = config.c config.h opendmarc.c opendmarc.h \
 	opendmarc-ar.c opendmarc-ar.h \
+	opendmarc-arcares.c opendmarc-arcares.h \
 	opendmarc-arcseal.c opendmarc-arcseal.h \
 	opendmarc-config.h \
 	opendmarc-dstring.c opendmarc-dstring.h \

--- a/opendmarc/opendmarc-arcares.h
+++ b/opendmarc/opendmarc-arcares.h
@@ -1,0 +1,142 @@
+/*
+**  Copyright (c) 2018, The Trusted Domain Project.
+**  	All rights reserved.
+**
+**  Implements functionality required to extract ARC authentication results
+**  details for inclusion in DMARC reporting.
+*/
+
+#ifndef _OPENDMARC_ARCARES_H_
+#define _OPENDMARC_ARCARES_H_
+
+/* system includes */
+#include <sys/types.h>
+
+/* opendmarc includes */
+#include "parse.h"
+
+/* boolean TRUE and FALSE */
+#ifndef FALSE
+# define FALSE		0
+#endif /* !FALSE */
+#ifndef TRUE
+# define TRUE		1
+#endif /* !TRUE */
+
+/*
+** limits
+*/
+
+/* buffer to cache a single header */
+#define OPENDMARC_ARCARES_MAXHEADER_LEN       4096
+/* max header tag value length (short) */
+#define OPENDMARC_ARCARES_MAX_SHORT_VALUE_LEN 256
+/* max header tag value length (long) */
+#define OPENDMARC_ARCARES_MAX_LONG_VALUE_LEN  512
+
+/* names and field labels */
+#define OPENDMARC_ARCARES_HDRNAME	"ARC-Authentication-Results"
+#define OPENDMARC_ARCARES_HDRNAME_LEN	sizeof(OPENDMARC_ARCARES_HDRNAME) - 1
+
+/* AAR_TAG_T -- type for specifying arc authentication results tag names */
+typedef int aar_tag_t;
+
+#define AAR_TAG_UNKNOWN     (-1)
+#define AAR_TAG_ARC         0
+#define AAR_TAG_AUTHSERV_ID 1
+#define AAR_TAG_DKIM        2
+#define AAR_TAG_DMARC       3
+#define AAR_TAG_INSTANCE    4
+#define AAR_TAG_SPF         5
+
+/* AAR_ARC_TAG_T -- type for specifying arc authentication results arc tag names */
+typedef int aar_arc_tag_t;
+
+#define AAR_ARC_TAG_UNKNOWN        (-1)
+#define AAR_ARC_TAG_ARC            0
+#define AAR_ARC_TAG_ARC_CHAIN      1
+#define AAR_ARC_TAG_SMTP_CLIENT_IP 2
+
+struct arcares_field
+{
+	u_char status[OPENDMARC_ARCARES_MAX_SHORT_VALUE_LEN];
+	u_char string[OPENDMARC_ARCARES_MAX_LONG_VALUE_LEN];
+};
+
+/* ARCARES structure -- the single header parsed */
+struct arcares
+{
+	int instance;
+	u_char authserv_id[OPENDMARC_ARCARES_MAX_SHORT_VALUE_LEN + 1];
+	u_char arc[OPENDMARC_ARCARES_MAX_LONG_VALUE_LEN + 1];
+	u_char dkim[OPENDMARC_ARCARES_MAX_LONG_VALUE_LEN + 1];
+	u_char dmarc[OPENDMARC_ARCARES_MAX_LONG_VALUE_LEN + 1];
+	u_char spf[OPENDMARC_ARCARES_MAX_LONG_VALUE_LEN + 1];
+};
+
+/* ARCARES_HEADER -- a node for a linked list of arcares structs */
+struct arcares_header
+{
+	struct arcares arcares;
+	struct arcares_header * arcares_next;
+	struct arcares_header * arcares_prev;
+};
+
+struct arcares_arc_field
+{
+	u_char arcresult[OPENDMARC_ARCARES_MAX_SHORT_VALUE_LEN + 1];
+	u_char smtpclientip[OPENDMARC_ARCARES_MAX_SHORT_VALUE_LEN + 1];
+	u_char arcchain[OPENDMARC_ARCARES_MAX_LONG_VALUE_LEN + 1];
+};
+
+/*
+** OPENDMARC_ARCARES_PARSE -- parse an ARC-Authentication-Results: header,
+**                             return a structure containing parse result
+**
+** Parameters:
+** 	hdr -- NULL-terminated contents of an ARC-Authentication-Results: header
+**             field
+** 	aar -- a pointer to a struct (arcaar) loaded by values after parsing
+**
+**  Returns:
+**  	0 on success, -1 on failure
+**/
+
+extern int opendmarc_arcares_parse __P((u_char *hdr, struct arcares *aar));
+
+/*
+** OPENDMARC_ARCARES_ARC+PARSE -- parse an ARC-Authentication-Results: header
+**                                ARC field, return a structure containing parse
+**                                result
+**
+** Parameters:
+** 	hdr_arc -- NULL-terminated contents of an ARC-Authentication-Results:
+**                 header ARC field
+** 	arc -- a pointer to a struct (arcares_arc_field) loaded by values after
+**             parsing
+**
+**  Returns:
+**  	0 on success, -1 on failure
+**/
+
+extern int opendmarc_arcares_arc_parse __P((u_char *hdr_arc,
+                                            struct arcares_arc_field *arc));
+
+/*
+**  OPENDMARC_ARCARES_LIST_PLUCK -- retrieve a struct (arcares) from a linked
+**                                  list corresponding to a specified instance
+**
+**  Parameters:
+**  	instance -- struct with instance value to find
+**  	aar_hdr -- address of list head pointer
+**  	aar -- a pointer to a struct (arcaar) loaded by values after parsing
+**
+**  Returns:
+**  	0 on success, -1 on failure
+*/
+
+extern int opendmarc_arcares_list_pluck(u_int instance,
+                                          struct arcares_header *aar_hdr,
+                                          struct arcares *aar);
+
+#endif /* _OPENDMARC_ARCARES_H_ */

--- a/opendmarc/opendmarc-arcseal.c
+++ b/opendmarc/opendmarc-arcseal.c
@@ -35,7 +35,7 @@ struct opendmarc_arcseal_lookup
 	int code;
 };
 
-struct opendmarc_arcseal_lookup tags[] =
+struct opendmarc_arcseal_lookup as_tags[] =
 {
 	{ "a",		AS_TAG_ALGORITHM },
 	{ "cv",		AS_TAG_CHAIN_VALIDATION },
@@ -199,6 +199,7 @@ opendmarc_arcseal_parse(u_char *hdr, struct arcseal *as)
 	u_char *token;
 	u_char token_buf[OPENDMARC_ARCSEAL_MAX_TOKEN_LEN + 1];
 	u_char tmp[OPENDMARC_ARCSEAL_MAXHEADER_LEN + 1];
+	int result = 0;
 
 	tmp_ptr = tmp;
 
@@ -224,7 +225,7 @@ opendmarc_arcseal_parse(u_char *hdr, struct arcseal *as)
 		tag_label = strsep(&token_ptr, "=");
 		tag_value = opendmarc_arcseal_strip_whitespace(token_ptr);
 
-		tag_code = opendmarc_arcseal_convert(tags, tag_label);
+		tag_code = opendmarc_arcseal_convert(as_tags, tag_label);
 
 		switch (tag_code)
 		{
@@ -257,9 +258,10 @@ opendmarc_arcseal_parse(u_char *hdr, struct arcseal *as)
 			break;
 
 		  default:
+			result = -1;
 			break;
 		}
 	}
 
-	return 0;
+	return result;
 }

--- a/opendmarc/opendmarc-arcseal.h
+++ b/opendmarc/opendmarc-arcseal.h
@@ -62,6 +62,14 @@ struct arcseal
 	u_char signature_value[OPENDMARC_ARCSEAL_MAX_LONG_VALUE_LEN + 1];
 };
 
+/* ARCSEAL_HEADER -- a node for a linked list of arcseal structs */
+struct arcseal_header
+{
+	struct arcseal arcseal;
+	struct arcseal_header * arcseal_next;
+	struct arcseal_header * arcseal_prev;
+};
+
 /*
 **  OPENDMARC_ARC_SEAL_PARSE -- parse an ARC-Seal: header, return a structure
 **                              containing a parsed result

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -120,14 +120,6 @@ struct dmarcf_header
 	struct dmarcf_header *	hdr_prev;
 };
 
-/* ARCSEAL_HEADER -- a linked list of arcseal structs */
-struct arcseal_header
-{
-	struct arcseal arcseal;
-	struct arcseal_header * arcseal_next;
-	struct arcseal_header * arcseal_prev;
-};
-
 /* DMARCF_MSGCTX -- message-specific context */
 struct dmarcf_msgctx
 {

--- a/reports/opendmarc-expire.in
+++ b/reports/opendmarc-expire.in
@@ -296,6 +296,17 @@ if (!defined($minmsg))
 
 		$dbi_s->finish;
 
+		$dbi_s = $dbi_h->prepare("TRUNCATE TABLE arcauthresults");
+		if (!$dbi_s->execute)
+		{
+			print STDERR "$progname: TRUNCATE failed: " . $dbi_h->errstr;
+			$dbi_s->finish;
+			$dbi_h->disconnect;
+			exit(1);
+		}
+
+		$dbi_s->finish;
+
 		$dbi_s = $dbi_h->prepare("TRUNCATE TABLE arcseals");
 		if (!$dbi_s->execute)
 		{
@@ -340,6 +351,32 @@ else
 	}
 
 	$dbi_s->finish;
+
+	if ($verbose)
+	{
+		print STDERR "$progname: expiring arcauthresults on expired messages (id < $minmsg)\n";
+	}
+
+	$dbi_s = $dbi_h->prepare("DELETE FROM arcauthresults WHERE message < ?");
+	$rows = $dbi_s->execute($minmsg);
+	if (!$rows)
+	{
+		print STDERR "$progname: DELETE failed: " . $dbi_h->errstr;
+		$dbi_s->finish;
+		$dbi_h->disconnect;
+		exit(1);
+	}
+	elsif ($verbose)
+	{
+		if ($rows eq "0E0")
+		{
+			print STDOUT "$progname: no rows deleted\n";
+		}
+		else
+		{
+			print STDOUT "$progname: $rows row(s) deleted\n";
+		}
+	}
 
 	if ($verbose)
 	{

--- a/reports/opendmarc-import.in
+++ b/reports/opendmarc-import.in
@@ -330,7 +330,6 @@ sub update_db
 		my $selector;
 		my $selector_id;
 		my $instance;
-		my $instance_id;
 
 		$instance = $arc_policy_data[$as]{'i'};
 		$sdomain = $arc_policy_data[$as]{'d'};

--- a/reports/opendmarc-import.in
+++ b/reports/opendmarc-import.in
@@ -322,6 +322,24 @@ sub update_db
 	}
 	$dbi_s->finish;
 
+	$dbi_s = $dbi_h->prepare("INSERT INTO arcauthresults (message, instance, arc_client_addr) VALUES(?, ?, ?)");
+	foreach my $aar (0 .. $#arc_policy_data)
+	{
+		my $instance;
+		my $arc_client_addr;
+
+		$instance = $arc_policy_data[$aar]{'i'};
+		$arc_client_addr = $arc_policy_data[$aar]{'ip'} || '';
+
+		if (!$dbi_s->execute($msg_id, $instance, $arc_client_addr))
+		{
+			print STDERR "$progname: failed to insert ARC-Authentication-Results data: " . $dbi_h->errstr . "\n";
+			$dbi_s->finish;
+			return;
+		}
+	}
+	$dbi_s->finish;
+
 	$dbi_s = $dbi_h->prepare("INSERT INTO arcseals (message, domain, selector, instance) VALUES(?, ?, ?, ?)");
 	foreach my $as (0 .. $#arc_policy_data)
 	{
@@ -553,6 +571,12 @@ while (<$inputfh>)
 
 	chomp;
 	($key, $value, $data) = split / /, $_, 3;
+
+	# skip lines that start with a space
+	if (!defined($key))
+	{
+		next;
+	}
 
 	if (defined($data) && length($data) > 0)
 	{

--- a/reports/opendmarc-reports.in
+++ b/reports/opendmarc-reports.in
@@ -722,12 +722,16 @@ foreach (@$domainset)
 			else	{ $arcpolicystr = "fail"; }
 		}
 
-		# retrieve arc_policy seals
+		# retrieve arc_policy seals, join arcauthresults.arc_client_addr (smtp.client_ip)
 		$dbi_s2 = $dbi_h->prepare(q{
-		                          SELECT arcseals.instance, domains.name AS domain, selectors.name AS selector
+		                          SELECT arcseals.instance, domains.name AS domain,
+						selectors.name AS selector,
+						arcauthresults.arc_client_addr as client_ip
 		                          FROM arcseals
 		                          JOIN domains on arcseals.domain = domains.id
 		                          JOIN selectors on arcseals.selector = selectors.id
+					  JOIN arcauthresults on arcseals.message = arcauthresults.message
+					  	AND arcseals.instance = arcauthresults.instance
 		                          WHERE arcseals.message = ?
 		                          ORDER BY arcseals.instance DESC
 		});
@@ -745,6 +749,10 @@ foreach (@$domainset)
 		{
 			$arc_policy_output .= " as[$dbi_hash->{instance}].d=$dbi_hash->{domain}";
 			$arc_policy_output .= " as[$dbi_hash->{instance}].s=$dbi_hash->{selector}";
+			if ($dbi_hash->{instance} == 1 && (defined($dbi_hash->{client_ip}) && $dbi_hash->{client_ip} ne ""))
+			{
+				$arc_policy_output .= " client-ip[$dbi_hash->{instance}]=$dbi_hash->{client_ip}";
+			}
 		}
 
 		$dbi_s2->finish;


### PR DESCRIPTION
As per: [draft-ietf-dmarc-arc-protocol-14 Section 6.3](https://tools.ietf.org/html/draft-ietf-dmarc-arc-protocol-14#section-6.3)

This update implements collection and reporting of the `AAR smtp.client-ip` as attached by [OpenARC](https://github.com/trusteddomainproject/OpenARC) and required in reporting as follows:

```xml
<policy_evaluated>
  <disposition>none</disposition>
  <dkim>fail</dkim>
  <spf>fail</spf>
  <reason>
   <type>local_policy</type>
   <comment>arc=pass ams[2].d=d2.example ams[2].s=s1 as[2].d=d2.example
     as[2].s=s2 as[1].d=d1.example as[1].s=s3 client-ip[1]=10.10.10.13</comment>
  </reason>
</policy_evaluated>
```

**NOTE**: As per spec, we only report the first hop but with that said, we record the ip for all hops.
