### PR TITLE
opendmarc-arcares.c:arc_parse: tokens are separated by colon

### DIFF
--- a/opendmarc/opendmarc-arcares.c
+++ b/opendmarc/opendmarc-arcares.c
@@ -310,7 +310,7 @@ opendmarc_arcares_arc_parse (u_char *hdr_arc, struct arcares_arc_field *arc)
 
 	memcpy(tmp, hdr_arc, MIN_OF(strlen(hdr_arc), sizeof tmp - 1));
 
-	while ((token = strsep((char **)&tmp_ptr, " ;")) != NULL)
+	while ((token = strsep((char **)&tmp_ptr, ";")) != NULL)
 	{
 		size_t leading_space_len;
 		aar_tag_t tag_code;


### PR DESCRIPTION
And not by colon or space.  The latter cannot deal with “arc=reject (some comment)”.  On the first iteration of the loop, tag_code is AAR_ARC_TAG_ARC and tag_value is reject.  On the second iteration, there is no equal sign in token_ptr, so token_ptr is NULL and then opendmarc_arcares_strip_whitespace(NULL) is called, which crashes in the assert.

opendmarc uses anyway only the smtpclienip from the parsed AAR.