### PR TITLE
Fix multiple addresses in From vulnerability

### DIFF
--- a/libopendmarc/tests/test_finddomain.c
+++ b/libopendmarc/tests/test_finddomain.c
@@ -23,6 +23,7 @@ main(int argc, char **argv)
 		/* 11 */ {"(,) joe@joe.com", "joe.com"},
 		/* 12 */ {"\"( bob@bob.com)\" joe@joe.com", "joe.com"},
 		/* 12 */ {"From: Davide D'Marco <user@blah.com>", "blah.com"},
+		/* 13 */ {"blah.com", "blah.com"},
 			 {NULL, NULL},
 	};
 	u_char dbuf[256];

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -2193,7 +2193,7 @@ mlfi_eom(SMFICTX *ctx)
 	strncpy(dfc->mctx_fromdomain, domain, sizeof dfc->mctx_fromdomain - 1);
 
 	ostatus = opendmarc_policy_store_from_domain(cc->cctx_dmarc,
-	                                             from->hdr_value);
+	                                             dfc->mctx_fromdomain);
 	if (ostatus != DMARC_PARSE_OKAY)
 	{
 		if (conf->conf_dolog)


### PR DESCRIPTION
This PR fixes vulnerability that allows opendmarc to pass as `example.com` since spf and dkim were not `example.com` in the following example:

Input:

```
From: Support <support@example.com>, Support <support@thedomain.com>
Authentication-Results: mail.example.com; spf=pass smtp.mailfrom=notify@seconddomain.com
Authentication-Results: mail.example.com; dkim=pass (1024-bit key) header.d=thedomain.com header.i=@thedomain.com header.b=\"xxxx\""
```

Output:

```
Authentication-Results: mail.example.com; dmarc=pass (p=quarantine dis=none) header.from=example.com
```