### PR TITLE
Add checks for longer than buffer while parsing record 

### DIFF
--- a/libopendmarc/opendmarc_policy.c
+++ b/libopendmarc/opendmarc_policy.c
@@ -1074,7 +1074,7 @@ opendmarc_policy_parse_dmarc(DMARC_POLICY_T *pctx, u_char *domain, u_char *recor
 					*yp = '\0';
 
 				xp = opendmarc_util_cleanup(xp, xbuf, sizeof xbuf);
-				if (xp != NULL || strlen((char *)xp) > 0)
+				if (xp != NULL && strlen((char *)xp) > 0)
 				{
 					/*
 					 * Be generous. Accept, for example, "rf=a, aspf=afrf or any
@@ -1090,6 +1090,11 @@ opendmarc_policy_parse_dmarc(DMARC_POLICY_T *pctx, u_char *domain, u_char *recor
 						return DMARC_PARSE_ERROR_BAD_VALUE;
 					}
 				}
+				else
+				{
+					return DMARC_PARSE_ERROR_BAD_VALUE;
+				}
+
 				if (yp != NULL)
 					xp = yp+1;
 				else
@@ -1116,11 +1121,16 @@ opendmarc_policy_parse_dmarc(DMARC_POLICY_T *pctx, u_char *domain, u_char *recor
 					*yp = '\0';
 
 				xp = opendmarc_util_cleanup(xp, xbuf, sizeof xbuf);
-				if (xp != NULL || strlen((char *)xp) > 0)
+				if (xp != NULL && strlen((char *)xp) > 0)
 				{
 					pctx->rua_list = opendmarc_util_pushargv(xp, pctx->rua_list,
 										&(pctx->rua_cnt));
 				}
+				else
+				{
+					return DMARC_PARSE_ERROR_BAD_VALUE;
+				}
+
 				if (yp != NULL)
 					xp = yp+1;
 				else
@@ -1148,11 +1158,16 @@ opendmarc_policy_parse_dmarc(DMARC_POLICY_T *pctx, u_char *domain, u_char *recor
 					*yp = '\0';
 
 				xp = opendmarc_util_cleanup(xp, xbuf, sizeof xbuf);
-				if (xp != NULL || strlen((char *)xp) > 0)
+				if (xp != NULL && strlen((char *)xp) > 0)
 				{
 					pctx->ruf_list = opendmarc_util_pushargv(xp, pctx->ruf_list,
 										&(pctx->ruf_cnt));
 				}
+				else
+				{
+					return DMARC_PARSE_ERROR_BAD_VALUE;
+				}
+
 				if (yp != NULL)
 					xp = yp+1;
 				else
@@ -1175,7 +1190,7 @@ opendmarc_policy_parse_dmarc(DMARC_POLICY_T *pctx, u_char *domain, u_char *recor
 					*yp = '\0';
 
 				xp = opendmarc_util_cleanup(xp, xbuf, sizeof xbuf);
-				if (xp != NULL || strlen((char *)xp) > 0)
+				if (xp != NULL && strlen((char *)xp) > 0)
 				{
 					switch ((int)*xp)
 					{
@@ -1197,6 +1212,11 @@ opendmarc_policy_parse_dmarc(DMARC_POLICY_T *pctx, u_char *domain, u_char *recor
 							return DMARC_PARSE_ERROR_BAD_VALUE;
 					}
 				}
+				else
+				{
+					return DMARC_PARSE_ERROR_BAD_VALUE;
+				}
+
 				if (yp != NULL)
 					xp = yp+1;
 				else

--- a/libopendmarc/tests/test_dmarc_parse.c
+++ b/libopendmarc/tests/test_dmarc_parse.c
@@ -34,6 +34,7 @@ main(int argc, char **argv)
 		/* 16 */ {"v=DMARC1; p=none; rua=ftp://abuse.com", DMARC_PARSE_OKAY},
 		/* 17 */ {"v=DMARC1; p=none; ruf=mailto://abuse.com", DMARC_PARSE_OKAY},
 		/* 18 */ {"v=DMARC1; p=none; ruf=mailto://abuse.com; foo=bar; buzz=happy;", DMARC_PARSE_OKAY},
+		/* 19 */ {"v=DMARC1; p=none; rf=000000000000000000000000000000000", DMARC_PARSE_ERROR_BAD_VALUE},
 			{NULL, 0},
 	};
 	int	pass, fails, count;


### PR DESCRIPTION
If a long or malformed DMARC record is parsed, the code ends up checking for the strlen of NULL pointer. Correct that, and return that the policy is invalid.

Additionally, add a test