### PR TITLE
Fix missing hsearch_r on macOS/Darwin

### DIFF
--- a/README
+++ b/README
@@ -43,6 +43,9 @@ o If you are interested in tinkering with the build and packaging structure,
 	automake (GNU automake) 1.7 (or 1.9 to avoid warnings)
 	ltmain.sh (GNU libtool) 2.2.6 (or 1.5.26 after make maintainer-clean)
 
+o macOS / Dawin systems do not have required functions hcreate_r(), hsearch_r()
+  and hdestroy_r() as standard. They can be provided by libc_hsearch_r.
+  See https://github.com/mikhail-j/libc_hsearch_r
 
 +-----------------------+
 | RELATED DOCUMENTATION |

--- a/configure.ac
+++ b/configure.ac
@@ -222,6 +222,19 @@ then
                   [Define to 1 if you need to include <opendmarc_strl.h> to get the `strlcat()' and `strlcpy()' functions.])
 fi
 
+# we need to include <search_hsearch_r.h> and add libhsearch_r to the library path if an installed
+# search_hsearch_r.h was found
+
+search_hsearch_r_found="no"
+AC_CHECK_HEADERS([search_hsearch_r.h], [search_hsearch_r_found="yes"])
+if test x"$search_hsearch_r_found" = x"yes"
+then
+        AC_DEFINE([USE_SEARCH_HSEARCH_R_H], 1,
+                  [Define to 1 if you need to include <search_hsearch_r.h> to get the `hcreate_r()', 'hsearch_r()', and 'hdestroy_r()' functions.])
+        saved_LIBS="$LIBS"
+        LIBS="$saved_LIBS -lhsearch_r"
+fi
+
 AC_PROG_LN_S
 AC_CHECK_PROG(miltertest, miltertest, "yes", "no")
 AC_SUBST(ac_aux_dir)

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -62,6 +62,11 @@
 /* hash support -- requires #define _GNU_SOURCE */
 #include <search.h>
 
+/* reentrant hash support if found */
+#ifdef USE_SEARCH_HSEARCH_R_H
+# include <search_hsearch_r.h>
+#endif /* USE_SEARCH_HSEARCH_R_H */
+
 /* opendmarc_strl if needed */
 #ifdef USE_DMARCSTRL_H
 # include <opendmarc_strl.h>


### PR DESCRIPTION
macOS/Darwin requires additional library and include files to provide hsearch extensions hcreate_r(), hsearch_r()  and hdestroy_r() in order to build opendmarc