### PR TITLE
Fix typos in man pages and sample config

### DIFF
--- a/opendmarc/opendmarc.8.in
+++ b/opendmarc/opendmarc.8.in
@@ -36,7 +36,7 @@ using a configuration file.  See the
 option for details.
 
 .B opendmarc
-relies on addition of Authentication-Results fields by upsteam filters on
+relies on addition of Authentication-Results fields by upstream filters on
 trusted hosts to collect input to the DMARC algorithm.  It does not itself
 do DKIM or SPF evaluation.
 .SH OPTIONS

--- a/opendmarc/opendmarc.conf.5.in
+++ b/opendmarc/opendmarc.conf.5.in
@@ -293,7 +293,7 @@ version, and the job ID are included in the header field's contents.
 .TP
 .I SPFIgnoreResults (Boolean)
 Causes the filter to ignore any SPF results in the header of the
-message.  This is useful if you want the filter to perfrom SPF checks
+message.  This is useful if you want the filter to perform SPF checks
 itself, or because you don't trust the arriving header.  The default is "false".
 
 .TP

--- a/opendmarc/opendmarc.conf.sample
+++ b/opendmarc/opendmarc.conf.sample
@@ -333,7 +333,7 @@
 ##	default "false"
 ##
 ##  Causes the filter to ignore any SPF results in the header of the
-##  message.  This is useful if you want the filter to perfrom SPF checks
+##  message.  This is useful if you want the filter to perform SPF checks
 ##  itself, or because you don't trust the arriving header.
 #
 # SPFIgnoreResults false


### PR DESCRIPTION
The proposed change fixes two typos found and flagged by Debian’s Lintian tool. Thank you.