### PR TITLE
Fix ressource leakage on systems using res_ndestroy()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -139,6 +139,16 @@ m4_define([AC_LANG_CALL], [AC_LANG_PROGRAM([#include <resolv.h>],
 AC_SEARCH_LIBS(res_ninit, resolv,
 	AC_DEFINE(HAVE_RES_NINIT, 1,
 	[Define to 1 if you have the `res_ninit()' function.]))
+AC_SEARCH_LIBS(res_ndestroy, resolv,
+        AC_DEFINE(HAVE_RES_NDESTROY, 1,
+        [Define to 1 if you have the `res_ndestroy()' function.]))
+AC_SEARCH_LIBS(__res_ninit, resolv,
+        AC_DEFINE(HAVE_RES_NINIT, 1,
+        [Define to 1 if you have the `__res_ninit()' function.]))
+AC_SEARCH_LIBS(__res_ndestroy, resolv,
+        AC_DEFINE(HAVE_RES_NDESTROY, 1,
+        [Define to 1 if you have the `__res_ndestroy()' function.]))
+ 
 m4_rename_force([saved_AC_LANG_CALL], [AC_LANG_CALL])
 AC_CHECK_LIB(idn, idn_free)
 AC_CHECK_LIB(rt, nanosleep)

--- a/libopendmarc/opendmarc_dns.c
+++ b/libopendmarc/opendmarc_dns.c
@@ -209,7 +209,11 @@ dmarc_dns_get_record(char *domain, int *reply, char *got_txtbuf, size_t got_txtl
 	(void) opendmarc_policy_library_dns_hook(&resp.nscount,
                                                  &resp.nsaddr_list);
 	answer_len = res_nquery(&resp, bp, C_IN, T_TXT, answer_buf, sizeof answer_buf);
+#ifdef HAVE_RES_NDESTROY
+	res_ndestroy(&resp);
+#else
 	res_nclose(&resp);
+#endif
 #else /* HAVE_RES_NINIT */
 	res_init();
 #ifdef RES_USE_DNSSEC

--- a/libopendmarc/opendmarc_spf_dns.c
+++ b/libopendmarc/opendmarc_spf_dns.c
@@ -108,7 +108,11 @@ opendmarc_spf_dns_lookup_a_actual(char *domain, int sought, char **ary, int *cnt
 
 #ifdef HAVE_RES_NINIT
 	k = res_nquery(&resp, bp, C_IN, sought, a_buf, sizeof a_buf);
+#ifdef HAVE_RES_NDESTROY
+	res_ndestroy(&resp);
+#else
 	res_nclose(&resp);
+#endif
 #else /* HAVE_RES_NINIT */
 	k = res_query(bp, C_IN, sought, a_buf, sizeof a_buf);
 #endif /* HAVE_RES_NINIT */
@@ -253,7 +257,11 @@ opendmarc_spf_dns_lookup_mx(char *domain, char **ary, int *cnt)
         memset(&resp, '\0', sizeof resp);
 	res_ninit(&resp);
 	k = res_nquery(&resp, domain, C_IN, T_MX, (u_char *) &q, sizeof(q));
+#ifdef HAVE_RES_NDESTROY
+	res_ndestroy(&resp);
+#else
 	res_nclose(&resp);
+#endif
 #else /* HAVE_RES_NINIT */
 	k = res_query(domain, C_IN, T_MX, (u_char *) &q, sizeof(q));
 #endif /* HAVE_RES_NINIT */
@@ -366,7 +374,11 @@ opendmarc_spf_dns_lookup_ptr(char *ip, char **ary, int *cnt)
         memset(&resp, '\0', sizeof resp);
 	res_ninit(&resp);
 	k = res_nquery(&resp, (char *)buf, C_IN, T_PTR, (u_char *) &q, sizeof(q));
+#ifdef HAVE_RES_NDESTROY
+	res_ndestroy(&resp);
+#else
 	res_nclose(&resp);
+#endif
 #else /* HAVE_RES_NINIT */
 	k = res_query((char *)buf, C_IN, T_PTR, (u_char *) &q, sizeof(q));
 #endif /* HAVE_RES_NINIT */
@@ -461,7 +473,11 @@ opendmarc_spf_dns_does_domain_exist(char *domain, int *reply)
         (void) res_nquery(&resp, domain, C_IN, T_AAAA, aaaa_q, sizeof aaaa_q);  
 #endif /* T_AAAA */
         (void) res_nquery(&resp, domain, C_IN, T_MX, mx_q, sizeof mx_q);  
+#ifdef HAVE_RES_NDESTROY
+	res_ndestroy(&resp);
+#else
 	res_nclose(&resp);
+#endif
 #else /* HAVE_RES_NINIT */
         (void) res_query(domain, C_IN, T_A, a_q, sizeof a_q);  
 #ifdef T_AAAA
@@ -603,13 +619,21 @@ opendmarc_spf_dns_get_record(char *domain, int *reply, char *txt, size_t txtlen,
 		}
 		*rp = h_errno;
 #ifdef HAVE_RES_NINIT 
+#ifdef HAVE_RES_NDESTROY
+		res_ndestroy(&resp);
+#else
 		res_nclose(&resp);
+#endif
 #endif /* HAVE_RES_NINIT */
 		return NULL;
 	}
 got_spf_record:
 #ifdef HAVE_RES_NINIT 
+#ifdef HAVE_RES_NDESTROY
+	res_ndestroy(&resp);
+#else
 	res_nclose(&resp);
+#endif
 #endif /* HAVE_RES_NINIT */
 
 	if (k > (int)(sizeof txt_buf))


### PR DESCRIPTION
Use res_ndestroy() instead of res_nclose() to properly cleanup resources
on NetBSD (and others that use __res_ndestroy() or res_ndestroy() instead
of res_nclose()). Original patch by Roy Marples.

Also, detect NetBSD's res_ninit().