### PR TITLE
Fix issue in libopendmarc leading to false DMARC pass results

### DIFF
--- a/libopendmarc/opendmarc_policy.c
+++ b/libopendmarc/opendmarc_policy.c
@@ -525,11 +525,16 @@ opendmarc_policy_store_dkim(DMARC_POLICY_T *pctx, u_char *d_equal_domain,
 			goto set_final;
 	}
 	/*
-	 * If we found any record so far that passed.
-	 * preserve it.
+	 * If we found any record so far that passed, preserve it; if the new entry
+	 * is not aligned, only replace an existing one by an unaligned one if it was
+	 * not a pass, but make sure to update the domain in that case!
 	 */
-	if (pctx->dkim_outcome == DMARC_POLICY_DKIM_OUTCOME_PASS)
+	if (pctx->dkim_outcome == DMARC_POLICY_DKIM_OUTCOME_PASS) {
 		return DMARC_PARSE_OKAY;
+	} else {
+		(void) free(pctx->dkim_domain);
+		pctx->dkim_domain = NULL;
+	}
 
 set_final:
 	if (pctx->dkim_domain == NULL)


### PR DESCRIPTION
Please note that this does not affect the opendmarc milter implementation, but can represent a severe issue for everything that uses libopendmarc directly (like we do).

If libopendmarc's library function `opendmarc_policy_store_dkim` is used to first store DMARC_POLICY_DKIM_OUTCOME_FAIL with domain _example.org_ and used to store another result DMARC_POLICY_DKIM_OUTCOME_PASS for _example.bad_ and the message's From: header is for _abc@example.org_, libopendmarc returns an DMARC_POLICY_DKIM_ALIGNMENT_PASS  result for _example.org_.

This would enable a malicious enitiy to craft messages with a valid DKIM signature for a domain under its control to produce DMARC pass results for arbitrary domains not under its control and thereby bypass the DMARC authentication mechanism, *if* libopendmarc is used to directly store DKIM results found in a message (which does seem to be a reasonable way to use the library).

The problem is that the dkim_outcome of the first passed result is overwritten (because the code priotizes PASS results over others), but the domain, which was set for the aligned DMARC_POLICY_DKIM_OUTCOME_FAIL result, is not updated on the second call.

The patch fixes this by just slightly adapting the logic to *always* reset (and update) the domain if the outcome is overwriitten.

The opendmarc milter is not affected by this, because it does only ever store DMARC_POLICY_DKIM_OUTCOME_PASS results using libopendmarc. 