### PR TITLE
Update dmarcf_mail_parse_multi()

### DIFF
--- a/opendmarc/Makefile.am
+++ b/opendmarc/Makefile.am
@@ -9,6 +9,12 @@ endif
 dist_doc_DATA = opendmarc.conf.sample
 
 sbin_PROGRAMS = opendmarc opendmarc-check
+check_PROGRAMS = parse_tests
+
+parse_tests_SOURCES = parse-tests.c /parse.c
+# parse_tests_CPPFLAGS = -I$(top_srcdir)/opendmarc
+
+TESTS = $(check_PROGRAMS)
 
 opendmarc_SOURCES = config.c config.h opendmarc.c opendmarc.h \
 	opendmarc-ar.c opendmarc-ar.h \

--- a/opendmarc/parse-tests.c
+++ b/opendmarc/parse-tests.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+
+#include "parse.h"
+
+int
+main() {
+	u_char **users, **domains;
+
+	int status = dmarcf_mail_parse_multi((unsigned char*)strdup("From: \"A, B\" <c@d.e>, abc@def.geh"), &users, &domains);
+	if (status) return status;
+	status = strcmp((char*)domains[0], "d.e") + strcmp((char*)domains[1], "def.geh") + strcmp((char*)users[0], "c") + strcmp((char*)users[1], "abc") + (users[2] != NULL) + (domains[2] != NULL);
+	if (status) return status;
+
+	status = dmarcf_mail_parse_multi((unsigned char*)strdup("From: abc@def.geh, \"A, B\" <c@d.e>"), &users, &domains);
+	if (status) return status;
+	status = strcmp((char*)domains[0], "def.geh") + strcmp((char*)domains[1], "d.e") + strcmp((char*)users[0], "abc") + strcmp((char*)users[1], "c") + (users[2] != NULL) + (domains[2] != NULL);
+	if (status) return status;
+
+	status = dmarcf_mail_parse_multi((unsigned char*)strdup("From: \"A, B\" <c@d.e>"), &users, &domains);
+	if (status) return status;
+	status = strcmp((char*)domains[0], "d.e") + strcmp((char*)users[0], "c") + strcmp((char*)users[0], "c") + (users[1] != NULL) + (domains[1] != NULL);
+	if (status) return status;
+
+	return status;
+}

--- a/opendmarc/parse.c
+++ b/opendmarc/parse.c
@@ -519,14 +519,13 @@ dmarcf_mail_parse_multi(unsigned char *line, unsigned char ***users_out,
 			escaped = FALSE;
 			continue;
 		}
-
 		switch (*p)
 		{
 		  case '\\':
 			escaped = TRUE;
 			continue;
 
-		  case ':':
+		  case '\"':
 			quoted = !quoted;
 			continue;
 
@@ -540,14 +539,12 @@ dmarcf_mail_parse_multi(unsigned char *line, unsigned char ***users_out,
 
 		  case ',':
 		  case '\0':
-			if (parens != 0)
+			if (parens != 0 || quoted)
 				continue;
-
 			if (*p == '\0')
 				done = TRUE;
 			else
 				*p = '\0';
-
 			status = dmarcf_mail_parse(addr, &u, &d);
 			if (status != 0)
 			{

--- a/opendmarc/parse.h
+++ b/opendmarc/parse.h
@@ -23,4 +23,7 @@
 extern int dmarcf_mail_parse __P((unsigned char *, unsigned char **,
                                   unsigned char **));
 
+extern int dmarcf_mail_parse_multi __P((unsigned char *, unsigned char ***,
+                                  unsigned char ***));
+
 #endif /* ! _DMARCF_MAILPARSE_H_ */


### PR DESCRIPTION
… to skip commas, when they are in quoted strings.  Such commas do not separate several addresses in the From: header.

* Add test cases.