### PR TITLE
Abandon ARC header parsing on unexpected data

### DIFF
--- a/opendmarc/opendmarc-arcares.c
+++ b/opendmarc/opendmarc-arcares.c
@@ -324,6 +324,8 @@ opendmarc_arcares_arc_parse (u_char *hdr_arc, struct arcares_arc_field *arc)
 		if (*token_ptr == '\0')
 			return 0;
 		tag_label = strsep(&token_ptr, "=");
+		if (token_ptr == NULL)
+			return -1;
 		tag_value = opendmarc_arcares_strip_whitespace(token_ptr);
 		tag_code = opendmarc_arcares_convert(aar_arc_tags, tag_label);
 

--- a/opendmarc/opendmarc-arcseal.c
+++ b/opendmarc/opendmarc-arcseal.c
@@ -223,7 +223,11 @@ opendmarc_arcseal_parse(u_char *hdr, struct arcseal *as)
 		if (*token_ptr == '\0')
 			return 0;
 		tag_label = strsep(&token_ptr, "=");
+		if (token_ptr == NULL)
+			return -1;
 		tag_value = opendmarc_arcseal_strip_whitespace(token_ptr);
+		if (tag_value == NULL)
+			return -1;
 
 		tag_code = opendmarc_arcseal_convert(as_tags, tag_label);
 


### PR DESCRIPTION
This change checks for null pointer and saves us a crash