### PR TITLE
Develop Make holding of p=quarantine messages optional. Partial patch by Marcos Moraes

### DIFF
--- a/opendmarc/opendmarc-config.h
+++ b/opendmarc/opendmarc-config.h
@@ -36,6 +36,7 @@ struct configdef dmarcf_config[] =
 	{ "FailureReportsOnNone",	CONFIG_TYPE_BOOLEAN,	FALSE },
 	{ "FailureReportsSentBy",	CONFIG_TYPE_STRING,	FALSE },
 	{ "HistoryFile",		CONFIG_TYPE_STRING,	FALSE },
+	{ "HoldQuarantinedMessages",    CONFIG_TYPE_BOOLEAN,    FALSE },
 	{ "IgnoreAuthenticatedClients",	CONFIG_TYPE_BOOLEAN,	FALSE },
 	{ "IgnoreHosts",		CONFIG_TYPE_STRING,	FALSE },
 	{ "IgnoreMailFrom",		CONFIG_TYPE_STRING,	FALSE },

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -177,6 +177,7 @@ struct dmarcf_config
 	_Bool			conf_spfselfvalidate;
 #endif /* WITH_SPF */
 	_Bool			conf_ignoreauthclients;
+	_Bool			conf_holdquarantinedmessages;
 	_Bool			conf_reject_multi_from;
 	unsigned int		conf_refcnt;
 	unsigned int		conf_dnstimeout;
@@ -1374,6 +1375,10 @@ dmarcf_config_load(struct config *data, struct dmarcf_config *conf,
 		(void) config_get(data, "RecordAllMessages",
 		                  &conf->conf_recordall,
 		                  sizeof conf->conf_recordall);
+
+		(void) config_get(data, "HoldQuarantinedMessages",
+				  &conf->conf_holdquarantinedmessages,
+				  sizeof conf->conf_holdquarantinedmessages);
 
 		(void) config_get(data, "IgnoreAuthenticatedClients",
 		                  &conf->conf_ignoreauthclients,
@@ -3440,7 +3445,8 @@ mlfi_eom(SMFICTX *ctx)
 		aresult = "fail";
 		ret = SMFIS_CONTINUE;
 
-		if (conf->conf_rejectfail && random() % 100 < pct)
+		if (conf->conf_rejectfail && conf->conf_holdquarantinedmessages &&
+		    random() % 100 < pct)
 		{
 			snprintf(replybuf, sizeof replybuf,
 			         "rejected by DMARC policy for %s", pdomain);

--- a/opendmarc/opendmarc.conf.5.in
+++ b/opendmarc/opendmarc.conf.5.in
@@ -192,6 +192,17 @@ aggregate reports can be extracted using
 .B opendmarc-importstats(8).
 
 .TP
+.I HoldQuarantinedMessages (Boolean)
+If set, the milter will signal to the mta that messages with
+p=quarantine, which fail dmarc authentication, should be held in
+the MTA's "Hold" or "Quarantine" queue.  The name varies by MTA.
+If false, messsages will be accepted and passed along with the 
+regular mail flow, and the quarantine will be left up to downstream
+MTA/MDA/MUA filters, if any, to handle by re-evaluating the headers,
+including the Authentication-Results header added by this filter.
+The default is "false".
+
+.TP
 .I IgnoreAuthenticatedClients (Boolean)
 If set, causes mail from authenticated clients (i.e., those that used
 SMTP AUTH) to be ignored by the filter.  The default is "false".

--- a/opendmarc/opendmarc.conf.sample
+++ b/opendmarc/opendmarc.conf.sample
@@ -221,6 +221,20 @@
 #
 # IgnoreAuthenticatedClients false
 
+## HoldQuarantinedMessages { true | false }
+##  	default "false"
+##
+##  If set, the milter will signal to the mta that messages with
+##  p=quarantine, which fail dmarc authentication, should be held in
+##  the MTA's "Hold" or "Quarantine" queue.  The name varies by MTA.
+##  If false, messsages will be accepted and passed along with the 
+##  regular mail flow, and the quarantine will be left up to downstream
+##  MTA/MDA/MUA filters, if any, to handle by re-evaluating the headers,
+##  including the Authentication-Results header added by OpenDMARC
+#
+# HoldQuarantinedMessages false
+
+
 ##  IgnoreHosts path
 ##  	default (internal)
 ##


### PR DESCRIPTION
Issue #77 (Sourceforge-138). Allow p=quarantine messages to pass. Adds new config option HoldQuarantinedMessages (default false).  Partial patch by Marcos Moraes