### PR TITLE
The big de-sourceforge-ification

### DIFF
--- a/HowToRelease
+++ b/HowToRelease
@@ -15,11 +15,11 @@ Release procedures for OpenDMARC
 	% make distcheck
 
    This will produce an opendmarc-(version).tar.gz tarball after running
-   all unit tests.
+   all unit tests.  (Although we leave it to github to create these for us now)
 
-3) Commit changes made to RELEASE_NOTES to the SourceForge git repository.
+3) Commit changes made to RELEASE_NOTES to the GitHub repository.
    Be sure to include any open feature requests, patches or bug fixes
-   from the SourceForge trackers.
+   from the GitHub issue list.
 
 4) Prepare a release announcement by using the file "announcement" from git
    as your template.  Change the From: to the name and address of the person
@@ -28,7 +28,7 @@ Release procedures for OpenDMARC
    or two at the top highlighting the interesting changes and indicating
    what the main focus of this release is (new features, bug fixes, etc.),
    and then the full RELEASE_NOTES block for the new release.  Commit this
-   to git.
+   to GitHub.
 
 5) Merge the "develop" branch to the "master" branch, as follows:
 
@@ -37,15 +37,11 @@ Release procedures for OpenDMARC
 	[massage in and commit any conflicts]
 	% git push
 
-6) Deploy all needed files to SourceForge by doing 'make push'.  This will
-   also place the release tag.
+6) Create a new release on GitHub per github docs:
+   https://docs.github.com/en/github/administering-a-repository/managing-releases-in-a-repository
 
-7) Via the SourceForge UI, make the latest tarball the default download for
-   all operating systems.
+   (This will create both the GitHub "tag" as well as the "release")
 
-8) Send the release announcement:
+7) Send the release announcement:
 
 	% sendmail -t < announcement
-
-9) Mark any bug fixes or feature requests, etc. as closed if this release
-   contained them.

--- a/README
+++ b/README
@@ -71,11 +71,15 @@ lists are:
 
 	opendmarc-code		Automated source code change announcements.
 
-Bug tracking is done via the trackers on SourceForge at
-http://sourceforge.net/projects/opendmarc.  You can enter new bug
-reports there, but please check first for older bugs already open,
-or even already closed, before opening a new issue.
+Bug tracking is done via the trackers on GitHub at:
 
+https://github.com/trusteddomainproject/OpenDMARC/issues  
+
+You can enter new bug reports there, but please check first for older bugs 
+already open, or even already closed, before opening a new issue.
+
+Note that development is being moved away from SourceForge, Freshmeat, or
+other sites.
 
 +---------------------+
 | DIRECTORY STRUCTURE |
@@ -144,13 +148,11 @@ MTA timeouts
 
 Other OpenDMARC issues:
 
- Report any bugs to the email address opendmarc-users@trusteddomain.org or to
- the SourceForge issue tracker accessible at:
- 
- http://sourceforge.net/p/opendmarc/tickets/
+Bug tracking is done via the trackers on GitHub at:
 
+https://github.com/trusteddomainproject/OpenDMARC/issues  
+
+Please report them there, after checking for prior reports.
 
 --
 Copyright (c) 2012, 2016, 2018, The Trusted Domain Project. All rights reserved.
-
-$Id: README,v 1.13 2010/10/25 20:41:55 cm-msk Exp $

--- a/announcement
+++ b/announcement
@@ -1,9 +1,9 @@
 From: Murray S. Kucherawy <msk@trusteddomain.org>
 To: opendmarc-announce@trusteddomain.org, opendmarc-users@trusteddomain.org
-Subject: OpenDMARC v1.3.2 released
+Subject: OpenDMARC !!!VERSION!!! released
 
 The Trusted Domain Project is pleased to announce the availability of
-OpenDMARC v1.3.2, now available for download from SourceForge.
+OpenDMARC v!!!VERSION!!! now available for download from SourceForge.
 
 This is mainly a bug fix release.  Upgrade is recommended.
 
@@ -13,80 +13,16 @@ community.  We thank those contributors for their ongoing support.
 The full RELEASE_NOTES for this version, showing changes since the last
 release:
 
-1.3.2		2017/03/04
-	Feature request #86: Change meaning of "RequiredHeaders" such that
-		header validity is always checked, but messages are only
-		rejected on that basis when the flag is set.  Based
-		on a patch from Andreas Schulze.
-	Feature request #127: Log SPF results when rejecting.  Requested
-		by Patrick Wagner; patch from Andreas Schulze, follow-up
-		patch from Juri Haberland.
-	Feature request #138: Inculde policy and disposition information
-		in an Authentication-Results comment.  Based on a patch
-		from Juri Haberland.
-	Feature request #139: Include the client host name if known
-		in failure reports.  Suggested by Roland Turner;
-		patch by Andreas Schulze.
-	Fix bug #95: Assume IPv6 for SPF operations.  Patch from Juri Haberland.
-	Fix bug #120: Fix control logic around the SPF result.
-		Reported by Christophe Wolfhugel; patch from Andreas Schulze.
-	Fix bug #122: Don't skip the HELO milter phase when SPF is enabled.
-		Reported by Christophe Wolfhugel.
-	Fix bug #157: Fix logging of implicit authserv-ids.  Reported
-		by Andreas Schulze; patch from Juri Haberland.
-	Fix bug #158: Log ignored connections.  Patch from Andreas Schulze.
-	Fix bug #160: Fix "SyslogFacility" handling.  Patch from
-		Juri Haberland.
-	Fix bug #163: Use a larger buffer for the raw MAIL FROM value.
-		Based on a patch from Andreas Schulze.
-	Fix bug #174: Trim "!" suffixes from reporting addresses.  Problem
-		noted by Juri Haberland.
-	Fix bug #186: When reloading the configuration file, the public
-		suffix list was read in with the wrong comment indicator.
-		Patch from Federico Omoto.
-	LIBOPENDMARC: Fix bug #115: Fix type mismatch.  Patch from
-		Sebastian A. Siewior via Scott Kitterman.
-	LIBOPENDMARC: Fix bug #121: Fix IPv6 CIDR matching in SPF code.
-		Patch from Christophe Wolfhugel.
-	LIBOPENDMARC: Fix bug #125: Compile time IPv6 fix.  Reported by
-		Christophe Wolfhugel.
-	LIBOPENDMARC: Fix bug #131: Fix alignment bug.  Patch from
-		Andreas Schulze.
-	LIBOPENDMARC: Fix bug #147: Fix stripping of whitespace from
-		DMARC DNS records.  Based on a patch from Job Noorman.
-	LIBOPENDMARC: Fix bug #149: Apply "sp" setting, if present and
-		applicable.  Patch from Petr Novak.
-	LIBOPENDMARC: Fix bug #154: Fix "rf" and "fo" processing logic.
-	LIBOPENDMARC: Fix bug #156: Fix variable name.  Patch by
-		Andreas Schulze.
-	LIBOPENDMARC: Fix bug #165: Fix logic in checking which SPF
-		identifier was used.  Patches from Marco Favero and
-		Juri Haberland.
-	LIBOPENDMARC: Fix bug #167: Don't return "fail" when we should
-		return "none".  Patch from Marco Favero.
-	REPORTS: Fix bug #134: Handle SMTP errors correctly.  Patch from
-		Andreas Schulze.
-	REPORTS: Fix bug #141: Set the HELO parameter correctly.
-		Reported by Alan Smith; patch from Andreas Schulze.
-	REPORTS: Fix bug #143: Fix logic in table truncation.
-		Reported by Wayne Andersen; patch from Juri Haberland.
-	REPORTS: Fix bug #162: Always report "sp" in aggregate reports.
-		Patch from Juri Haberland.
-	REPORTS: Fix bug #166: Fix report start/end time logic.
-		Patch from Juri Haberland.
-	REPORTS: Fix bug #188: Don't delete inputs too early in
-		opendmarc-reports.  Patch from Juri Haberland.
-	TOOLS: Fix bug #161: "Forensic" reports were renamed "Failure"
-		reports.  Patch from Andreas Schulze.
-	TOOLS: Fix bug #164: Handle IPv6 test addresses.  Reported by
-		Andreas Schulze; patch from Juri Haberland.
-	DOCS: Patch #189: Replace the DMARC RFC with an HTML page
-		referencing the relevant specs, since Debian doesn't
-		consider RFCs to be "free".  Patch from Scott Kitterman
-		via Juri Haberland.
+!!!PUT-RELEASE-NOTES-HERE!!!
 
-Please use the trackers on SourceForge at
-https://sourceforge.net/p/opendmarc/tickets/ to file problem reports,
-or the mailing lists for more general discussion and questions.
+Please use the trackers on GitHub at:
+
+https://github.com/trusteddomainproject/OpenDMARC/issues
+
+to file problem reports, or the mailing lists for more general discussion and questions.
+
+Prior versions of this project used SourceForge and/or Freshmeat, which are
+officially deprecated.  If you had submitted an issue there, please see if it is
+still relevant and consider re-filing it as a GitHub issue.
 
 The Trusted Domain Project

--- a/configure.ac
+++ b/configure.ac
@@ -55,6 +55,16 @@ HEX_VERSION=$(printf %08x $(( ((VERSION_RELEASE << 8 | VERSION_MAJOR_REV) << 8 |
 AC_SUBST([HEX_VERSION])
 
 #
+# version string for GitHub assets
+# https://github.com/trusteddomainproject/OpenDMARC/archive/rel-opendmarc-1-4-0.tar.gz
+# https://github.com/trusteddomainproject/OpenDMARC/archive/rel-opendmarc-1-4-0-Beta1.tar.gz
+# Beta tag is passed to RPM by downstream packagers and expanded there.
+#
+GITHUB_VERSION=$(printf %d-%d-%d VERSION_RELEASE VERSION_MAJOR_REV VERSION_MINOR_REV)
+AC_SUBST([GITHUB_VERSION])#
+
+
+#
 # library version, passed to libtool
 #
 LIBOPENDMARC_VERSION_INFO=$(printf %d:%d:%d LIBVERSION_CURRENT LIBVERSION_REVISION LIBVERSION_AGE)

--- a/contrib/spec/opendmarc.spec.in
+++ b/contrib/spec/opendmarc.spec.in
@@ -1,12 +1,15 @@
 # Pass --define "BETA 3" to build name-version.0.Beta3.1.arch
-%define BetaTag %{?BETA:.Beta%{BETA}}
+# GitHubVersion will be determined by autoconf
+
+%global BetaTag %{?BETA:.Beta%{BETA}}
+%global GitHubVersion @GITHUB_VERSION@
 
 Summary: DMARC milter and library
 Name: opendmarc
 Version: @VERSION@
 Release: %{?BETA:0%{BetaTag}.}1%{?dist}
 License: BSD and Sendmail
-URL: http://http://www.trusteddomain.org/opendmarc.html
+URL: http://www.trusteddomain.org/opendmarc.html
 Group: System Environment/Daemons
 Requires: lib%{name} = %{version}-%{release}
 Requires (pre): shadow-utils
@@ -15,7 +18,9 @@ Requires (preun): chkconfig, initscripts
 Requires (postun): initscripts
 BuildRequires: sendmail-devel, openssl-devel, libtool, pkgconfig
 BuildRequires: mysql-devel
-Source0: http://downloads.sourceforge.net/%{name}/%{name}-%{version}%{BetaTag}.tar.gz
+# https://github.com/trusteddomainproject/OpenDMARC/archive/rel-opendmarc-1-4-0.tar.gz
+# https://github.com/trusteddomainproject/OpenDMARC/archive/rel-opendmarc-1-4-0-Beta1.tar.gz
+Source0: https://github.com/trusteddomainproject/%{name}/rel-%{name}-%{GitHubVersion}%{BetaTag}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 %description

--- a/opendmarc/README
+++ b/opendmarc/README
@@ -91,6 +91,12 @@ CONFIGURING OPENDMARC
 
 	/etc/init.d/postfix restart
 
+(9) Depending on your settings, mail sent with a policy of p=quarantine
+    may wind up in your MTA's "Hold" or "Quarantine" queue.
+
+	The setting "HoldQuarantinedMessages" (defaults to false) can be used
+	to control this feature.
+
 
 TESTING AND DEBUGGING
 =====================
@@ -220,5 +226,5 @@ subscribe to one or both of the following:
 
 These can be accessed via http://www.trusteddomain.org/mailman/listinfo.
 
-To report bugs and feature requests, you can access the SourceForge "tracker"
-facilities at http://sourceforge.net/projects/opendmarc.
+To report bugs and feature requests, you can access the GitHub "tracker"
+facilities at https://github.com/trusteddomainproject/OpenDMARC/issues.

--- a/www/index.html
+++ b/www/index.html
@@ -14,7 +14,7 @@
 		the DMARC specification.  You can browse the source code,
 		download the latest released version, and access the bug and
 		other issue trackers
-		<a href="http://sourceforge.net/projects/opendmarc">here</a>.
+		<a href="https://github.com/trusteddomainproject/OpenDMARC">here</a>.
 	</p>
 
 	<p>


### PR DESCRIPTION
This removes most references to Sourceforge from the code and docs.  Notes are put in place as a deprecation warning, and to encourage people to see if old issues are worth re-opening on GitHub.

Updates were made to "HowToRelease" but those may need further notes by Murray.  Also, I've cleared out the "meat" of the announcement file, as it will only be re-updated with the current release notes.  The "make push" line in the makefile remains, but may eventually go away.

I've recreated the contrib/spec/opendmarc.spec.in using nomenclature specific with the way github creates their release tags, as well as adding a line to configure.ac to generate a GITHUB_VERSION macro.  At some point, we should be running rpmlint on the specfile as part of the QA process, but I don't have that available yet.  (Unknown if anyone even is using our .spec file -- if nobody is, it should probably be removed).

For future work, trusteddomain.org's website should have https:// enabled and all urls herein should point to those instead of plain http:// (not strictly speaking a GitHub'able issue)