### PR TITLE
Convert strings to all be "char *".

### DIFF
--- a/libopendmarc/dmarc.h
+++ b/libopendmarc/dmarc.h
@@ -93,7 +93,7 @@ extern "C" {
 #define OPENDMARC_MAX_NSADDRLIST (8)
 typedef struct {
 	int			tld_type;
-	u_char 			tld_source_file[MAXPATHLEN];
+	char 			tld_source_file[MAXPATHLEN];
 	int    			nscount;
 	struct sockaddr_in 	nsaddr_list[MAXNS];
 } OPENDMARC_LIB_T;
@@ -110,7 +110,7 @@ OPENDMARC_STATUS_T  opendmarc_policy_library_shutdown(OPENDMARC_LIB_T *lib_init)
 /*
  * Context management.
  */
-DMARC_POLICY_T * opendmarc_policy_connect_init(u_char *ip_addr, int ip_type);
+DMARC_POLICY_T * opendmarc_policy_connect_init(char *ip_addr, int ip_type);
 DMARC_POLICY_T * opendmarc_policy_connect_clear(DMARC_POLICY_T *pctx);
 DMARC_POLICY_T * opendmarc_policy_connect_rset(DMARC_POLICY_T *pctx);
 DMARC_POLICY_T * opendmarc_policy_connect_shutdown(DMARC_POLICY_T *pctx);
@@ -118,16 +118,16 @@ DMARC_POLICY_T * opendmarc_policy_connect_shutdown(DMARC_POLICY_T *pctx);
 /*
  * Store information routines.
  */
-OPENDMARC_STATUS_T opendmarc_policy_store_from_domain(DMARC_POLICY_T *pctx, u_char *domain);
-OPENDMARC_STATUS_T opendmarc_policy_store_dkim(DMARC_POLICY_T *pctx, u_char *domain, u_char *selector, int result, u_char *human_result);
-OPENDMARC_STATUS_T opendmarc_policy_store_spf(DMARC_POLICY_T *pctx, u_char *domain, int result, int origin, u_char *human_result);
+OPENDMARC_STATUS_T opendmarc_policy_store_from_domain(DMARC_POLICY_T *pctx, char *domain);
+OPENDMARC_STATUS_T opendmarc_policy_store_dkim(DMARC_POLICY_T *pctx, char *domain, char *selector, int result, char *human_result);
+OPENDMARC_STATUS_T opendmarc_policy_store_spf(DMARC_POLICY_T *pctx, char *domain, int result, int origin, char *human_result);
 
 /*
  * The DMARC record itself.
  */
-OPENDMARC_STATUS_T opendmarc_policy_query_dmarc(DMARC_POLICY_T *pctx, u_char *domain);
-OPENDMARC_STATUS_T opendmarc_policy_parse_dmarc(DMARC_POLICY_T *pctx, u_char *domain, u_char *record);
-OPENDMARC_STATUS_T opendmarc_policy_store_dmarc(DMARC_POLICY_T *pctx, u_char *dmarc_record, u_char *domain, u_char *organizationaldomain);
+OPENDMARC_STATUS_T opendmarc_policy_query_dmarc(DMARC_POLICY_T *pctx, char *domain);
+OPENDMARC_STATUS_T opendmarc_policy_parse_dmarc(DMARC_POLICY_T *pctx, char *domain, char *record);
+OPENDMARC_STATUS_T opendmarc_policy_store_dmarc(DMARC_POLICY_T *pctx, char *dmarc_record, char *domain, char *organizationaldomain);
 
 /*
  * Access to parts of the DMARC record.
@@ -139,11 +139,11 @@ OPENDMARC_STATUS_T opendmarc_policy_fetch_adkim(DMARC_POLICY_T *pctx, int *adkim
 OPENDMARC_STATUS_T opendmarc_policy_fetch_aspf(DMARC_POLICY_T *pctx, int *aspf);
 OPENDMARC_STATUS_T opendmarc_policy_fetch_p(DMARC_POLICY_T *pctx, int *p);
 OPENDMARC_STATUS_T opendmarc_policy_fetch_sp(DMARC_POLICY_T *pctx, int *sp);
-u_char **	   opendmarc_policy_fetch_rua(DMARC_POLICY_T *pctx, u_char *list_buf, size_t size_of_buf, int constant);
-u_char **	   opendmarc_policy_fetch_ruf(DMARC_POLICY_T *pctx, u_char *list_buf, size_t size_of_buf, int constant);
-OPENDMARC_STATUS_T opendmarc_policy_fetch_utilized_domain(DMARC_POLICY_T *pctx, u_char *buf, size_t buflen);
-OPENDMARC_STATUS_T opendmarc_policy_fetch_from_domain(DMARC_POLICY_T *pctx, u_char *buf, size_t buflen);
-OPENDMARC_STATUS_T opendmarc_policy_query_dmarc_xdomain(DMARC_POLICY_T *pctx, u_char *uri);
+char **            opendmarc_policy_fetch_rua(DMARC_POLICY_T *pctx, char *list_buf, size_t size_of_buf, int constant);
+char **            opendmarc_policy_fetch_ruf(DMARC_POLICY_T *pctx, char *list_buf, size_t size_of_buf, int constant);
+OPENDMARC_STATUS_T opendmarc_policy_fetch_utilized_domain(DMARC_POLICY_T *pctx, char *buf, size_t buflen);
+OPENDMARC_STATUS_T opendmarc_policy_fetch_from_domain(DMARC_POLICY_T *pctx, char *buf, size_t buflen);
+OPENDMARC_STATUS_T opendmarc_policy_query_dmarc_xdomain(DMARC_POLICY_T *pctx, char *uri);
 OPENDMARC_STATUS_T opendmarc_get_policy_token_used(DMARC_POLICY_T *pctx);
 
 /*
@@ -155,16 +155,16 @@ void		   opendmarc_tld_shutdown(void);
 /*
  * XML Parsing
  */
-u_char **          opendmarc_xml(char *b, size_t blen, char *e, size_t elen);
-u_char **          opendmarc_xml_parse(char *fname, char *err_buf, size_t err_len);
+char **          opendmarc_xml(char *b, size_t blen, char *e, size_t elen);
+char **          opendmarc_xml_parse(char *fname, char *err_buf, size_t err_len);
 
 /*
  * Utility routines
  */
 void		   opendmarc_dns_fake_record(const char *name, const char *answer);
-u_char ** 	   opendmarc_util_clearargv(u_char **ary);
+char ** 	   opendmarc_util_clearargv(char **ary);
 const char *	   opendmarc_policy_status_to_str(OPENDMARC_STATUS_T status);
-int                opendmarc_policy_check_alignment(u_char *subdomain, u_char *tld, int mode);
+int                opendmarc_policy_check_alignment(char *subdomain, char *tld, int mode);
 int 		   opendmarc_policy_to_buf(DMARC_POLICY_T *pctx, char *buf, size_t buflen);
 
 /*

--- a/libopendmarc/opendmarc_internal.h
+++ b/libopendmarc/opendmarc_internal.h
@@ -124,17 +124,17 @@ typedef struct dmarc_policy_t {
 	/*
 	 * Supplied information
 	 */
-	u_char *	ip_addr;		/* Input: connected IPV4 or IPV6 address */
+	char *		ip_addr;		/* Input: connected IPV4 or IPV6 address */
 	int 		ip_type;		/* Input: IPv4 or IPv6 */
-	u_char * 	spf_domain;		/* Input: Domain used to verify SPF */
+	char * 		spf_domain;		/* Input: Domain used to verify SPF */
 	int 	 	spf_origin;		/* Input: was domain MAIL From: or HELO for SPF check */
 	int		spf_outcome;		/* Input: What was the outcome of the SPF check */
-	u_char *	spf_human_outcome;	/* Input: What was the outcome of the SPF check in human readable form */
+	char *		spf_human_outcome;	/* Input: What was the outcome of the SPF check in human readable form */
 	int		dkim_final;		/* This is the best record found */
-	u_char * 	dkim_domain;		/* Input: The d= domain */
-	u_char *	dkim_selector;		/* Input: The s= selector */
+	char * 		dkim_domain;		/* Input: The d= domain */
+	char *		dkim_selector;		/* Input: The s= selector */
 	int		dkim_outcome;		/* Input: What was the outcome of the DKIM check */
-	u_char *	dkim_human_outcome;	/* Input: What was the outcome of the DKIM check in human readable form */
+	char *		dkim_human_outcome;	/* Input: What was the outcome of the DKIM check in human readable form */
 
 	/*
 	 * Computed outcomes
@@ -145,8 +145,8 @@ typedef struct dmarc_policy_t {
 	/*
 	 * Computed Organizational domain, if subdomain lacked a record.
 	 */
-	u_char *	from_domain;		/* Input: From: header domain */
-	u_char *	organizational_domain;
+	char *		from_domain;		/* Input: From: header domain */
+	char *		organizational_domain;
 
 	/*
 	 * Found in the _dmarc record or supplied to us.
@@ -160,9 +160,9 @@ typedef struct dmarc_policy_t {
 	int		rf;
 	uint32_t	ri;
 	int		rua_cnt;
-	u_char **	rua_list;
+	char **		rua_list;
 	int		ruf_cnt;
-	u_char **	ruf_list;
+	char **		ruf_list;
 	int		fo;
 } DMARC_POLICY_T;
 #ifndef OPENDMARC_POLICY_C
@@ -216,16 +216,16 @@ int           		opendmarc_hash_expire(OPENDMARC_HASH_CTX *hctx, time_t age);
 
 /* opendmarc_tld.c */
 int 			opendmarc_tld_read_file(char *path_fname, char *commentstring, char *drop, char *except);
-int 			opendmarc_get_tld(u_char *domain, u_char *tld, size_t tld_len);
-int                     opendmarc_reverse_domain(u_char *domain, u_char *buf, size_t buflen);
+int 			opendmarc_get_tld(char *domain, char *tld, size_t tld_len);
+int                     opendmarc_reverse_domain(char *domain, char *buf, size_t buflen);
 void 			opendmarc_tld_shutdown();
 
 /* opendmarc_util.c */
-u_char ** opendmarc_util_pushargv(u_char *str, u_char **ary, int *cnt);
-u_char ** opendmarc_util_clearargv(u_char **ary);
-u_char ** opendmarc_util_dupe_argv(u_char **ary);
-u_char *  opendmarc_util_cleanup(u_char *str, u_char *buf, size_t buflen);
-u_char *  opendmarc_util_finddomain(u_char *raw, u_char *buf, size_t buflen);
+char ** opendmarc_util_pushargv(char *str, char **ary, int *cnt);
+char ** opendmarc_util_clearargv(char **ary);
+char ** opendmarc_util_dupe_argv(char **ary);
+char *  opendmarc_util_cleanup(char *str, char *buf, size_t buflen);
+char *  opendmarc_util_finddomain(char *raw, char *buf, size_t buflen);
 char **   opendmarc_util_freenargv(char **ary, int *num);
 char **   opendmarc_util_pushnargv(char *str, char **ary, int *num);
 char *    opendmarc_util_ultoa(unsigned long val, char *buffer, size_t bufferlen);

--- a/libopendmarc/opendmarc_policy.c
+++ b/libopendmarc/opendmarc_policy.c
@@ -95,7 +95,7 @@ opendmarc_policy_library_shutdown(OPENDMARC_LIB_T *lib_init)
 **		Allocates memory.
 ***************************************************************************/
 DMARC_POLICY_T *
-opendmarc_policy_connect_init(u_char *ip_addr, int is_ipv6)
+opendmarc_policy_connect_init(char *ip_addr, int is_ipv6)
 {
 	DMARC_POLICY_T *pctx;
 	int		xerrno;
@@ -113,7 +113,7 @@ opendmarc_policy_connect_init(u_char *ip_addr, int is_ipv6)
 	(void) memset(pctx, '\0', sizeof(DMARC_POLICY_T));
 	pctx->p = DMARC_RECORD_P_UNSPECIFIED;
 	pctx->sp = DMARC_RECORD_P_UNSPECIFIED;
-	pctx->ip_addr = (u_char *)strdup((char *)ip_addr);
+	pctx->ip_addr = strdup((char *)ip_addr);
 	if (pctx->ip_addr == NULL)
 	{
 		xerrno = errno;
@@ -193,7 +193,7 @@ opendmarc_policy_connect_clear(DMARC_POLICY_T *pctx)
 DMARC_POLICY_T *
 opendmarc_policy_connect_rset(DMARC_POLICY_T *pctx)
 {
-	u_char *ip_save;
+	char *ip_save;
 	int     ip_type;
 
 	if (pctx == NULL)
@@ -240,12 +240,12 @@ opendmarc_policy_connect_shutdown(DMARC_POLICY_T *pctx)
 }
 
 int
-opendmarc_policy_check_alignment(u_char *subdomain, u_char *tld, int mode)
+opendmarc_policy_check_alignment(char *subdomain, char *tld, int mode)
 {
-	u_char rev_sub[512];
-	u_char rev_tld[512];
-	u_char tld_buf[512];
-	u_char *ep;
+	char rev_sub[512];
+	char rev_tld[512];
+	char tld_buf[512];
+	char *ep;
 	int	ret;
 
 	if (subdomain == NULL)
@@ -331,7 +331,7 @@ opendmarc_policy_check_alignment(u_char *subdomain, u_char *tld, int mode)
 **		puney decoded into 8-bit data.
 ***************************************************************************/
 OPENDMARC_STATUS_T
-opendmarc_policy_store_from_domain(DMARC_POLICY_T *pctx, u_char *from_domain)
+opendmarc_policy_store_from_domain(DMARC_POLICY_T *pctx, char *from_domain)
 {
 	char domain_buf[256];
 	char *dp;
@@ -376,7 +376,7 @@ opendmarc_policy_store_from_domain(DMARC_POLICY_T *pctx, u_char *from_domain)
 **		puney decoded into 8-bit data.
 ***************************************************************************/
 OPENDMARC_STATUS_T
-opendmarc_policy_store_spf(DMARC_POLICY_T *pctx, u_char *domain, int result, int origin, u_char *human_readable)
+opendmarc_policy_store_spf(DMARC_POLICY_T *pctx, char *domain, int result, int origin, char *human_readable)
 {
 	char domain_buf[256];
 	char *dp;
@@ -444,11 +444,11 @@ opendmarc_policy_store_spf(DMARC_POLICY_T *pctx, u_char *domain, int result, int
 **		puney decoded into 8-bit data.
 ***************************************************************************/
 OPENDMARC_STATUS_T
-opendmarc_policy_store_dkim(DMARC_POLICY_T *pctx, u_char *d_equal_domain,
-	u_char *s_equal_selector, int dkim_result, u_char *human_result)
+opendmarc_policy_store_dkim(DMARC_POLICY_T *pctx, char *d_equal_domain,
+	char *s_equal_selector, int dkim_result, char *human_result)
 {
 	char	domain_buf[256];
-	u_char *dp;
+	char *dp;
 	int	result = DMARC_POLICY_DKIM_OUTCOME_NONE;
 
 	if (pctx == NULL)
@@ -571,14 +571,14 @@ set_final:
 ** 
 ***************************************************************************/
 OPENDMARC_STATUS_T
-opendmarc_policy_query_dmarc_xdomain(DMARC_POLICY_T *pctx, u_char *uri)
+opendmarc_policy_query_dmarc_xdomain(DMARC_POLICY_T *pctx, char *uri)
 {
-	u_char buf[BUFSIZ];
-	u_char copy[256];
-	u_char domain[256];
-	u_char domain_tld[256];
-	u_char uri_tld[256];
-	u_char *ret = NULL;
+	char buf[BUFSIZ];
+	char copy[256];
+	char domain[256];
+	char domain_tld[256];
+	char uri_tld[256];
+	char *ret = NULL;
 	int dns_reply = 0;
 	int i = 0;
 	int err = 0;
@@ -620,7 +620,7 @@ opendmarc_policy_query_dmarc_xdomain(DMARC_POLICY_T *pctx, u_char *uri)
 	/* Query DNS */
 	for (i = 0; i < DNS_MAX_RETRIES && ret == NULL; i++)
 	{
-		ret = (u_char *) dmarc_dns_get_record((char *) copy, &dns_reply,
+		ret = dmarc_dns_get_record((char *) copy, &dns_reply,
 		                                      (char *) buf, sizeof buf);
 		if (ret != 0 || dns_reply == HOST_NOT_FOUND)
 			break;
@@ -649,7 +649,7 @@ opendmarc_policy_query_dmarc_xdomain(DMARC_POLICY_T *pctx, u_char *uri)
 	strlcat((char *) copy, (char *) domain, sizeof copy);
 	for (i = 0; i < DNS_MAX_RETRIES && ret == NULL; i++)
 	{
-		ret = (u_char *) dmarc_dns_get_record((char *) copy, &dns_reply,
+		ret = dmarc_dns_get_record((char *) copy, &dns_reply,
 		                                      (char *) buf, sizeof buf);
 		if (ret != 0 || dns_reply == HOST_NOT_FOUND)
 			break;
@@ -718,12 +718,12 @@ opendmarc_policy_query_dmarc_xdomain(DMARC_POLICY_T *pctx, u_char *uri)
 ** 
 ***************************************************************************/
 OPENDMARC_STATUS_T
-opendmarc_policy_query_dmarc(DMARC_POLICY_T *pctx, u_char *domain)
+opendmarc_policy_query_dmarc(DMARC_POLICY_T *pctx, char *domain)
 {
-	u_char 		buf[BUFSIZ];
-	u_char 		copy[256];
-	u_char 		tld[256];
-	u_char *	bp = NULL;
+	char 		buf[BUFSIZ];
+	char 		copy[256];
+	char 		tld[256];
+	char *		bp = NULL;
 	int		dns_reply = 0;
 	int		tld_reply = 0;
 	int		loop_count = DNS_MAX_RETRIES;
@@ -905,12 +905,12 @@ opendmarc_get_policy_to_enforce(DMARC_POLICY_T *pctx)
 **		Allocates memory.
 *********************************************************************************/
 OPENDMARC_STATUS_T
-opendmarc_policy_parse_dmarc(DMARC_POLICY_T *pctx, u_char *domain, u_char *record)
+opendmarc_policy_parse_dmarc(DMARC_POLICY_T *pctx, char *domain, char *record)
 {
-	u_char *cp, *eqp, *ep, *sp, *vp;
-	u_char copy[BUFSIZ];
-	u_char cbuf[512];
-	u_char vbuf[512];
+	char *cp, *eqp, *ep, *sp, *vp;
+	char copy[BUFSIZ];
+	char cbuf[512];
+	char vbuf[512];
 
 	if (pctx == NULL || domain == NULL || record == NULL || strlen((char *)record) == 0)
 	{
@@ -929,10 +929,10 @@ opendmarc_policy_parse_dmarc(DMARC_POLICY_T *pctx, u_char *domain, u_char *recor
 
 	for (cp = copy; cp != NULL && cp <= ep; )
 	{
-		sp = (u_char *)strchr(cp, ';');
+		sp = strchr(cp, ';');
 		if (sp != NULL)
 			*sp++ = '\0';
-		eqp = (u_char *)strchr((char *)cp, '=');
+		eqp = strchr((char *)cp, '=');
 		if (eqp == NULL)
 		{
 			cp = sp;
@@ -1075,7 +1075,7 @@ opendmarc_policy_parse_dmarc(DMARC_POLICY_T *pctx, u_char *domain, u_char *recor
 			 */
 			for (xp = vp; *xp != '\0'; )
 			{
-				u_char xbuf[32];
+				char xbuf[32];
 
 				yp = strchr(xp, ',');
 				if (yp != NULL)
@@ -1122,7 +1122,7 @@ opendmarc_policy_parse_dmarc(DMARC_POLICY_T *pctx, u_char *domain, u_char *recor
 
 			for (xp = vp; *xp != '\0'; )
 			{
-				u_char	xbuf[256];
+				char	xbuf[256];
 
 				yp = strchr(xp, ',');
 				if (yp != NULL)
@@ -1159,7 +1159,7 @@ opendmarc_policy_parse_dmarc(DMARC_POLICY_T *pctx, u_char *domain, u_char *recor
 
 			for (xp = vp; *xp != '\0'; )
 			{
-				u_char	xbuf[256];
+				char	xbuf[256];
 
 				yp = strchr(xp, ',');
 				if (yp != NULL)
@@ -1191,7 +1191,7 @@ opendmarc_policy_parse_dmarc(DMARC_POLICY_T *pctx, u_char *domain, u_char *recor
 			 */
 			for (xp = vp; *xp != '\0'; )
 			{
-				u_char xbuf[256];
+				char xbuf[256];
 
 				yp = strchr(xp, ':');
 				if (yp != NULL)
@@ -1265,7 +1265,7 @@ opendmarc_policy_parse_dmarc(DMARC_POLICY_T *pctx, u_char *domain, u_char *recor
 **					and hands it to us here.
 ***************************************************************************/
 OPENDMARC_STATUS_T
-opendmarc_policy_store_dmarc(DMARC_POLICY_T *pctx, u_char *dmarc_record, u_char *domain, u_char *organizationaldomain)
+opendmarc_policy_store_dmarc(DMARC_POLICY_T *pctx, char *dmarc_record, char *domain, char *organizationaldomain)
 {
 	OPENDMARC_STATUS_T status;
 
@@ -1287,7 +1287,7 @@ opendmarc_policy_store_dmarc(DMARC_POLICY_T *pctx, u_char *dmarc_record, u_char 
 	{
 		if (pctx->organizational_domain != NULL)
 			(void) free(pctx->organizational_domain);
-		pctx->organizational_domain = (u_char *)strdup(organizationaldomain);
+		pctx->organizational_domain = (char *)strdup(organizationaldomain);
 	}
 	return DMARC_PARSE_OKAY;
 }
@@ -1372,10 +1372,10 @@ opendmarc_policy_fetch_sp(DMARC_POLICY_T *pctx, int *sp)
 	return DMARC_PARSE_OKAY;
 }
 
-u_char **
-opendmarc_policy_fetch_rua(DMARC_POLICY_T *pctx, u_char *list_buf, size_t size_of_buf, int constant)
+char **
+opendmarc_policy_fetch_rua(DMARC_POLICY_T *pctx, char *list_buf, size_t size_of_buf, int constant)
 {
-	u_char *sp, *ep, *rp;
+	char *sp, *ep, *rp;
 	int	i;
 	int	ret;
 
@@ -1430,10 +1430,10 @@ opendmarc_policy_fetch_alignment(DMARC_POLICY_T *pctx, int *dkim_alignment, int 
 	return DMARC_PARSE_OKAY;
 }
 
-u_char **
-opendmarc_policy_fetch_ruf(DMARC_POLICY_T *pctx, u_char *list_buf, size_t size_of_buf, int constant)
+char **
+opendmarc_policy_fetch_ruf(DMARC_POLICY_T *pctx, char *list_buf, size_t size_of_buf, int constant)
 {
-	u_char *sp, *ep, *rp;
+	char *sp, *ep, *rp;
 	int	i;
 	int	ret;
 
@@ -1512,9 +1512,9 @@ opendmarc_policy_fetch_rf(DMARC_POLICY_T *pctx, int *rf)
 **		DMARC_PARSE_ERROR_NO_DOMAIN 	-- If neigher address is available
 **/
 OPENDMARC_STATUS_T
-opendmarc_policy_fetch_utilized_domain(DMARC_POLICY_T *pctx, u_char *buf, size_t buflen)
+opendmarc_policy_fetch_utilized_domain(DMARC_POLICY_T *pctx, char *buf, size_t buflen)
 {
-	u_char *which = NULL;
+	char *which = NULL;
 
 	if (pctx == NULL)
 		return DMARC_PARSE_ERROR_NULL_CTX;
@@ -1548,9 +1548,9 @@ opendmarc_policy_fetch_utilized_domain(DMARC_POLICY_T *pctx, u_char *buf, size_t
 **		DMARC_PARSE_ERROR_NO_DOMAIN 	-- If neigher address is available
 **/
 OPENDMARC_STATUS_T
-opendmarc_policy_fetch_from_domain(DMARC_POLICY_T *pctx, u_char *buf, size_t buflen)
+opendmarc_policy_fetch_from_domain(DMARC_POLICY_T *pctx, char *buf, size_t buflen)
 {
-	u_char *which = NULL;
+	char *which = NULL;
 
 	if (pctx == NULL)
 		return DMARC_PARSE_ERROR_NULL_CTX;

--- a/libopendmarc/opendmarc_tld.c
+++ b/libopendmarc/opendmarc_tld.c
@@ -26,10 +26,10 @@ static OPENDMARC_HASH_CTX *TLDbak_hctx = NULL;
 static char TLDfile[MAXPATHLEN];
 
 int
-opendmarc_reverse_domain(u_char *domain, u_char *buf, size_t buflen)
+opendmarc_reverse_domain(char *domain, char *buf, size_t buflen)
 {
-	u_char *dp, *ep, *cp;
-	u_char  copy[MAXDNSHOSTNAME];
+	char *dp, *ep, *cp;
+	char  copy[MAXDNSHOSTNAME];
 
 	if (buf == NULL || buflen == 0 || domain == NULL)
 	{
@@ -107,12 +107,12 @@ int
 opendmarc_tld_read_file(char *path_fname, char *commentstring, char *drop, char *except)
 {
 	FILE *	fp;
-	u_char 	buf[BUFSIZ];
+	char 	buf[BUFSIZ];
 	char *	cp;
 	void *	vp;
 	int	nlines=0;
 	int	ret;
-	u_char	revbuf[MAXDNSHOSTNAME];
+	char	revbuf[MAXDNSHOSTNAME];
 	int	adddot;
 	int	preflen;
 	OPENDMARC_HASH_CTX *hashp;
@@ -160,7 +160,7 @@ opendmarc_tld_read_file(char *path_fname, char *commentstring, char *drop, char 
 						break;
 				}
 				*ep = '\0';
-				ret = opendmarc_reverse_domain((u_char *)cp, revbuf, sizeof revbuf);
+				ret = opendmarc_reverse_domain(cp, revbuf, sizeof revbuf);
 				adddot = TRUE;
 				goto got_xn;
 			}
@@ -231,12 +231,12 @@ opendmarc_tld_shutdown()
 }
 
 int
-opendmarc_get_tld(u_char *domain, u_char *tld, size_t tld_len)
+opendmarc_get_tld(char *domain, char *tld, size_t tld_len)
 {
 	int	ret;
-	u_char	revbuf[MAXDNSHOSTNAME];
-	u_char *rp;
-	u_char  save;
+	char	revbuf[MAXDNSHOSTNAME];
+	char *rp;
+	char  save;
 	void *	vp;
 	
 	if (domain == NULL || tld == NULL || tld_len == 0)

--- a/libopendmarc/opendmarc_util.c
+++ b/libopendmarc/opendmarc_util.c
@@ -29,12 +29,12 @@
 **	Side Effects:
 **		Allocates and reallocates memory.
 */
-u_char **
-opendmarc_util_clearargv(u_char **ary)
+char **
+opendmarc_util_clearargv(char **ary)
 {
 	if (ary != NULL)
 	{
-		u_char **arp;
+		char **arp;
 
 		for (arp = ary; *arp != NULL; ++arp)
 		{
@@ -60,11 +60,11 @@ opendmarc_util_clearargv(u_char **ary)
 **	Side Effects:
 **		Allocates and reallocates memory.
 */
-u_char **
-opendmarc_util_pushargv(u_char *str, u_char **ary, int *cnt)
+char **
+opendmarc_util_pushargv(char *str, char **ary, int *cnt)
 {
 	int   	 i;
-	u_char **tmp;
+	char **tmp;
 
 	if (str == NULL)
 		return ary;
@@ -122,20 +122,20 @@ opendmarc_util_pushargv(u_char *str, u_char **ary, int *cnt)
 **	Parameters:
 **		ary	-- Pointer to array to dupe
 **	Returns:
-**		u_char **	-- On success
+**		char **	-- On success
 **		NULL		-- on error
 **	Side Effects:
 **		Allocates and reallocates memory.
 */
-u_char **
-opendmarc_util_dupe_argv(u_char **ary)
+char **
+opendmarc_util_dupe_argv(char **ary)
 {
-	u_char **new = NULL;
+	char **new = NULL;
 	int      new_cnt = 0;
 
 	if (ary != NULL)
 	{
-		u_char **arp;
+		char **arp;
 
 		for (arp = ary; *arp != NULL; ++arp)
 			new = opendmarc_util_pushargv(*arp, new, &new_cnt);
@@ -155,8 +155,8 @@ opendmarc_util_dupe_argv(u_char **ary)
 **		NULL on error and sets errno.
 **	Side Effects:
 */
-u_char *
-opendmarc_util_cleanup(u_char *str, u_char *buf, size_t buflen)
+char *
+opendmarc_util_cleanup(char *str, char *buf, size_t buflen)
 {
 	char *sp, *ep;
 
@@ -192,14 +192,14 @@ opendmarc_util_cleanup(u_char *str, u_char *buf, size_t buflen)
 **	        "foo" <a@a.com> "foo" --> a.com
 **		a@a.com, b@b.com, c@c.com --> a.com
 */
-u_char *
-opendmarc_util_finddomain(u_char *raw, u_char *buf, size_t buflen)
+char *
+opendmarc_util_finddomain(char *raw, char *buf, size_t buflen)
 {
-	u_char *a     	= NULL;
-	u_char *b     	= NULL;
-	u_char *ep    	= NULL;
-	u_char  copy[BUFSIZ];
-	u_char *cp	= NULL;
+	char *a     	= NULL;
+	char *b     	= NULL;
+	char *ep    	= NULL;
+	char  copy[BUFSIZ];
+	char *cp	= NULL;
 	int 	inparen	= 0;
 #define OPENDMARC_MAX_QUOTES (256)
 	int	quotes[OPENDMARC_MAX_QUOTES + 1];

--- a/libopendmarc/opendmarc_xml.c
+++ b/libopendmarc/opendmarc_xml.c
@@ -85,7 +85,7 @@ tag_lookup(char *tag)
 # define MAX_ITEM_NAME_LEN	(256)
 typedef char STACK[MAX_STACK_DEPTH][MAX_STACK_LINE_LEN];
 
-u_char **
+char **
 opendmarc_xml(char *b, size_t blen, char *e, size_t elen)
 {
 	STACK		stack;
@@ -94,7 +94,7 @@ opendmarc_xml(char *b, size_t blen, char *e, size_t elen)
 	int		i;
 	int		inside = FALSE;
 	char		org_name[MAX_ITEM_NAME_LEN];
-	u_char **	ary			= NULL;
+	char **		ary			= NULL;
 	int		ary_cnt			= 0;
 	char		begin[MAX_ITEM_NAME_LEN];
 	char		end[MAX_ITEM_NAME_LEN];
@@ -145,7 +145,7 @@ opendmarc_xml(char *b, size_t blen, char *e, size_t elen)
 
 	(void) memset(obuf, '\0', sizeof obuf);
 	(void) strlcpy(obuf, "begin,end,org_name,email,domain,adkim,aspf,p,pct,source_ip,count,disposition,policy_eval_dkim,policy_eval_spf,reason_type,reason_comment,header_from,auth_dkim_domain,auth_dkim_result,auth_dkim_human,auth_spf_domain,auth_spf_result,auth_spf_human", sizeof obuf);
-	ary = opendmarc_util_pushargv((u_char *)obuf, ary, &ary_cnt);
+	ary = opendmarc_util_pushargv(obuf, ary, &ary_cnt);
 
 	ep = b + blen;
 	for (cp = b; cp < ep; ++cp)
@@ -235,7 +235,7 @@ opendmarc_xml(char *b, size_t blen, char *e, size_t elen)
 					(void) strlcat(obuf, ",", sizeof obuf);
 					(void) strlcat(obuf, auth_spf_human, sizeof obuf);
 					(void) strlcat(obuf, ",", sizeof obuf);
-					ary = opendmarc_util_pushargv((u_char *)obuf, ary, &ary_cnt);
+					ary = opendmarc_util_pushargv(obuf, ary, &ary_cnt);
 					if (ary == NULL)
 					{
 						int xerror = errno;
@@ -531,7 +531,7 @@ opendmarc_xml(char *b, size_t blen, char *e, size_t elen)
 	return ary;
 }
 
-u_char **
+char **
 opendmarc_xml_parse(char *fname, char *err_buf, size_t err_len)
 {
 	struct stat	statb;
@@ -539,7 +539,7 @@ opendmarc_xml_parse(char *fname, char *err_buf, size_t err_len)
 	char *		bufp;
 	char		e_buf[128];
 	int		ret;
-	u_char **	ary = NULL;
+	char **		ary = NULL;
 	int		xerror;
 	size_t		rb;
 

--- a/opendmarc/opendmarc-ar.c
+++ b/opendmarc/opendmarc-ar.c
@@ -115,17 +115,17 @@ struct lookup ptypes[] =
 */
 
 static int
-ares_tokenize(u_char *input, u_char *outbuf, size_t outbuflen,
-              u_char **tokens, int ntokens)
+ares_tokenize(char *input, char *outbuf, size_t outbuflen,
+              char **tokens, int ntokens)
 {
 	_Bool quoted = FALSE;
 	_Bool escaped = FALSE;
 	_Bool intok = FALSE;
 	int n = 0;
 	int parens = 0;
-	u_char *p;
-	u_char *q;
-	u_char *end;
+	char *p;
+	char *q;
+	char *end;
 
 	assert(input != NULL);
 	assert(outbuf != NULL);
@@ -357,7 +357,7 @@ ares_xconvert(struct lookup *table, int code)
 */
 
 int
-ares_parse(u_char *hdr, struct authres *ar)
+ares_parse(char *hdr, struct authres *ar)
 {
 	_Bool quoted;
 	int n;
@@ -366,8 +366,8 @@ ares_parse(u_char *hdr, struct authres *ar)
 	int r = 0;
 	int state;
 	int prevstate;
-	u_char tmp[MAXHEADER + 2];
-	u_char *tokens[ARES_MAXTOKENS];
+	char tmp[MAXHEADER + 2];
+	char *tokens[ARES_MAXTOKENS];
 
 	assert(hdr != NULL);
 	assert(ar != NULL);
@@ -654,8 +654,8 @@ main(int argc, char **argv)
 	char *p;
 	char *progname;
 	struct authres ar;
-	u_char buf[1024];
-	u_char *toks[NTOKENS];
+	char buf[1024];
+	char *toks[NTOKENS];
 
 	progname = (p = strrchr(argv[0], '/')) == NULL ? argv[0] : p + 1;
 

--- a/opendmarc/opendmarc-ar.h
+++ b/opendmarc/opendmarc-ar.h
@@ -73,17 +73,17 @@ struct result
 	ares_method_t	result_method;
 	ares_result_t	result_result;
 	ares_ptype_t	result_ptype[MAXPROPS];
-	unsigned char	result_reason[MAXAVALUE + 1];
-	unsigned char	result_property[MAXPROPS][MAXAVALUE + 1];
-	unsigned char	result_value[MAXPROPS][MAXAVALUE + 1];
+	char	result_reason[MAXAVALUE + 1];
+	char	result_property[MAXPROPS][MAXAVALUE + 1];
+	char	result_value[MAXPROPS][MAXAVALUE + 1];
 };
 
 /* AUTHRES structure -- the entire header parsed */
 struct authres
 {
 	int		ares_count;
-	unsigned char	ares_host[DMARC_MAXHOSTNAMELEN + 1];
-	unsigned char	ares_version[MAXAVALUE + 1];
+	char	ares_host[DMARC_MAXHOSTNAMELEN + 1];
+	char	ares_version[MAXAVALUE + 1];
 	struct result	ares_result[MAXARESULTS];
 };
 
@@ -100,6 +100,6 @@ struct authres
 **  	0 on success, -1 on failure.
 */
 
-extern int ares_parse __P((u_char *hdr, struct authres *ar));
+extern int ares_parse __P((char *hdr, struct authres *ar));
 
 #endif /* _OPENDMARC_AR_H_ */

--- a/opendmarc/opendmarc-arcares.c
+++ b/opendmarc/opendmarc-arcares.c
@@ -99,7 +99,7 @@ opendmarc_arcares_convert(struct opendmarc_arcares_lookup *table, char *str)
 **/
 
 static char *
-opendmarc_arcares_strip_whitespace(u_char *string)
+opendmarc_arcares_strip_whitespace(char *string)
 {
 	assert(string != NULL);
 
@@ -145,7 +145,7 @@ opendmarc_arcares_strip_whitespace(u_char *string)
 **/
 
 static int
-opendmarc_arcares_strip_field_name(u_char *field, u_char *name, u_char *delim,
+opendmarc_arcares_strip_field_name(char *field, char *name, char *delim,
                                    char *buf, size_t buf_len)
 {
 	size_t copy_len;
@@ -153,7 +153,7 @@ opendmarc_arcares_strip_field_name(u_char *field, u_char *name, u_char *delim,
 	size_t delim_len;
 	size_t leading_space_len;
 	size_t field_value_len;
-	u_char *field_value_ptr;
+	char *field_value_ptr;
 
 	assert(field != NULL);
 	assert(name != NULL);
@@ -168,7 +168,7 @@ opendmarc_arcares_strip_field_name(u_char *field, u_char *name, u_char *delim,
 		return -1;
 
 	/* build delimited name */
-	u_char name_delim[OPENDMARC_ARCARES_MAX_FIELD_NAME_LEN + 1];
+	char name_delim[OPENDMARC_ARCARES_MAX_FIELD_NAME_LEN + 1];
 	memcpy(name_delim, (const void *) name, name_len);
 	memcpy(name_delim + name_len, delim, delim_len);
 	memset(name_delim + name_len + delim_len, '\0', sizeof(char));
@@ -203,13 +203,13 @@ opendmarc_arcares_strip_field_name(u_char *field, u_char *name, u_char *delim,
 **/
 
 int
-opendmarc_arcares_parse (u_char *hdr, struct arcares *aar)
+opendmarc_arcares_parse (char *hdr, struct arcares *aar)
 {
 	int result = 0;
-	u_char *tmp_ptr;
-	u_char *token;
-	u_char token_buf[OPENDMARC_ARCARES_MAX_TOKEN_LEN + 1];
-	u_char tmp[OPENDMARC_ARCARES_MAXHEADER_LEN + 1];
+	char *tmp_ptr;
+	char *token;
+	char token_buf[OPENDMARC_ARCARES_MAX_TOKEN_LEN + 1];
+	char tmp[OPENDMARC_ARCARES_MAXHEADER_LEN + 1];
 
 	assert(hdr != NULL);
 	assert(aar != NULL);
@@ -292,12 +292,12 @@ opendmarc_arcares_parse (u_char *hdr, struct arcares *aar)
 **/
 
 int
-opendmarc_arcares_arc_parse (u_char *hdr_arc, struct arcares_arc_field *arc)
+opendmarc_arcares_arc_parse (char *hdr_arc, struct arcares_arc_field *arc)
 {
-	u_char *tmp_ptr;
-	u_char *token;
-	u_char token_buf[OPENDMARC_ARCARES_MAX_TOKEN_LEN + 1];
-	u_char tmp[OPENDMARC_ARCARES_MAXHEADER_LEN + 1];
+	char *tmp_ptr;
+	char *token;
+	char token_buf[OPENDMARC_ARCARES_MAX_TOKEN_LEN + 1];
+	char tmp[OPENDMARC_ARCARES_MAXHEADER_LEN + 1];
 	int result = 0;
 
 	tmp_ptr = tmp;

--- a/opendmarc/opendmarc-arcares.h
+++ b/opendmarc/opendmarc-arcares.h
@@ -59,19 +59,19 @@ typedef int aar_arc_tag_t;
 
 struct arcares_field
 {
-	u_char status[OPENDMARC_ARCARES_MAX_SHORT_VALUE_LEN];
-	u_char string[OPENDMARC_ARCARES_MAX_LONG_VALUE_LEN];
+	char status[OPENDMARC_ARCARES_MAX_SHORT_VALUE_LEN];
+	char string[OPENDMARC_ARCARES_MAX_LONG_VALUE_LEN];
 };
 
 /* ARCARES structure -- the single header parsed */
 struct arcares
 {
 	int instance;
-	u_char authserv_id[OPENDMARC_ARCARES_MAX_SHORT_VALUE_LEN + 1];
-	u_char arc[OPENDMARC_ARCARES_MAX_LONG_VALUE_LEN + 1];
-	u_char dkim[OPENDMARC_ARCARES_MAX_LONG_VALUE_LEN + 1];
-	u_char dmarc[OPENDMARC_ARCARES_MAX_LONG_VALUE_LEN + 1];
-	u_char spf[OPENDMARC_ARCARES_MAX_LONG_VALUE_LEN + 1];
+	char authserv_id[OPENDMARC_ARCARES_MAX_SHORT_VALUE_LEN + 1];
+	char arc[OPENDMARC_ARCARES_MAX_LONG_VALUE_LEN + 1];
+	char dkim[OPENDMARC_ARCARES_MAX_LONG_VALUE_LEN + 1];
+	char dmarc[OPENDMARC_ARCARES_MAX_LONG_VALUE_LEN + 1];
+	char spf[OPENDMARC_ARCARES_MAX_LONG_VALUE_LEN + 1];
 };
 
 /* ARCARES_HEADER -- a node for a linked list of arcares structs */
@@ -84,9 +84,9 @@ struct arcares_header
 
 struct arcares_arc_field
 {
-	u_char arcresult[OPENDMARC_ARCARES_MAX_SHORT_VALUE_LEN + 1];
-	u_char smtpclientip[OPENDMARC_ARCARES_MAX_SHORT_VALUE_LEN + 1];
-	u_char arcchain[OPENDMARC_ARCARES_MAX_LONG_VALUE_LEN + 1];
+	char arcresult[OPENDMARC_ARCARES_MAX_SHORT_VALUE_LEN + 1];
+	char smtpclientip[OPENDMARC_ARCARES_MAX_SHORT_VALUE_LEN + 1];
+	char arcchain[OPENDMARC_ARCARES_MAX_LONG_VALUE_LEN + 1];
 };
 
 /*
@@ -102,7 +102,7 @@ struct arcares_arc_field
 **  	0 on success, -1 on failure
 **/
 
-extern int opendmarc_arcares_parse __P((u_char *hdr, struct arcares *aar));
+extern int opendmarc_arcares_parse __P((char *hdr, struct arcares *aar));
 
 /*
 ** OPENDMARC_ARCARES_ARC+PARSE -- parse an ARC-Authentication-Results: header
@@ -119,7 +119,7 @@ extern int opendmarc_arcares_parse __P((u_char *hdr, struct arcares *aar));
 **  	0 on success, -1 on failure
 **/
 
-extern int opendmarc_arcares_arc_parse __P((u_char *hdr_arc,
+extern int opendmarc_arcares_arc_parse __P((char *hdr_arc,
                                             struct arcares_arc_field *arc));
 
 /*

--- a/opendmarc/opendmarc-arcseal.c
+++ b/opendmarc/opendmarc-arcseal.c
@@ -88,7 +88,7 @@ opendmarc_arcseal_convert(struct opendmarc_arcseal_lookup *table, char *str)
 **/
 
 static char *
-opendmarc_arcseal_strip_whitespace(u_char *string)
+opendmarc_arcseal_strip_whitespace(char *string)
 {
 	assert(string != NULL);
 
@@ -134,7 +134,7 @@ opendmarc_arcseal_strip_whitespace(u_char *string)
 **/
 
 static int
-opendmarc_arcseal_strip_field_name(u_char *field, u_char *name, u_char *delim,
+opendmarc_arcseal_strip_field_name(char *field, char *name, char *delim,
                                    char *buf, size_t buf_len)
 {
 	size_t copy_len;
@@ -142,7 +142,7 @@ opendmarc_arcseal_strip_field_name(u_char *field, u_char *name, u_char *delim,
 	size_t delim_len;
 	size_t leading_space_len;
 	size_t field_value_len;
-	u_char *field_value_ptr;
+	char *field_value_ptr;
 
 	assert(field != NULL);
 	assert(name != NULL);
@@ -157,7 +157,7 @@ opendmarc_arcseal_strip_field_name(u_char *field, u_char *name, u_char *delim,
 		return -1;
 
 	/* build delimited name */
-	u_char name_delim[OPENDMARC_ARCSEAL_MAX_FIELD_NAME_LEN + 1];
+	char name_delim[OPENDMARC_ARCSEAL_MAX_FIELD_NAME_LEN + 1];
 	memcpy(name_delim, (const void *)name, name_len);
 	memcpy(name_delim + name_len, delim, delim_len);
 	memset(name_delim + name_len + delim_len, '\0', sizeof(char));
@@ -191,12 +191,12 @@ opendmarc_arcseal_strip_field_name(u_char *field, u_char *name, u_char *delim,
 **/
 
 int
-opendmarc_arcseal_parse(u_char *hdr, struct arcseal *as)
+opendmarc_arcseal_parse(char *hdr, struct arcseal *as)
 {
-	u_char *tmp_ptr;
-	u_char *token;
-	u_char token_buf[OPENDMARC_ARCSEAL_MAX_TOKEN_LEN + 1];
-	u_char tmp[OPENDMARC_ARCSEAL_MAXHEADER_LEN + 1];
+	char *tmp_ptr;
+	char *token;
+	char token_buf[OPENDMARC_ARCSEAL_MAX_TOKEN_LEN + 1];
+	char tmp[OPENDMARC_ARCSEAL_MAXHEADER_LEN + 1];
 	int result = 0;
 
 	tmp_ptr = tmp;

--- a/opendmarc/opendmarc-arcseal.h
+++ b/opendmarc/opendmarc-arcseal.h
@@ -54,12 +54,12 @@ typedef int as_tag_t;
 struct arcseal
 {
 	int instance;
-	u_char algorithm[OPENDMARC_ARCSEAL_MAX_SHORT_VALUE_LEN + 1];
-	u_char chain_validation[OPENDMARC_ARCSEAL_MAX_SHORT_VALUE_LEN + 1];
-	u_char signature_domain[OPENDMARC_ARCSEAL_MAX_SHORT_VALUE_LEN + 1];
-	u_char signature_selector[OPENDMARC_ARCSEAL_MAX_SHORT_VALUE_LEN + 1];
-	u_char signature_time[OPENDMARC_ARCSEAL_MAX_SHORT_VALUE_LEN + 1];
-	u_char signature_value[OPENDMARC_ARCSEAL_MAX_LONG_VALUE_LEN + 1];
+	char algorithm[OPENDMARC_ARCSEAL_MAX_SHORT_VALUE_LEN + 1];
+	char chain_validation[OPENDMARC_ARCSEAL_MAX_SHORT_VALUE_LEN + 1];
+	char signature_domain[OPENDMARC_ARCSEAL_MAX_SHORT_VALUE_LEN + 1];
+	char signature_selector[OPENDMARC_ARCSEAL_MAX_SHORT_VALUE_LEN + 1];
+	char signature_time[OPENDMARC_ARCSEAL_MAX_SHORT_VALUE_LEN + 1];
+	char signature_value[OPENDMARC_ARCSEAL_MAX_LONG_VALUE_LEN + 1];
 };
 
 /* ARCSEAL_HEADER -- a node for a linked list of arcseal structs */
@@ -82,6 +82,6 @@ struct arcseal_header
 **  	0 on success, -1 on failure
 **/
 
-extern int opendmarc_arcseal_parse __P((u_char *hdr, struct arcseal *as));
+extern int opendmarc_arcseal_parse __P((char *hdr, struct arcseal *as));
 
 #endif /* _OPENDMARC_ARCSEAL_H_ */

--- a/opendmarc/opendmarc-check.c
+++ b/opendmarc/opendmarc-check.c
@@ -63,8 +63,8 @@ main(int argc, char **argv)
 	char *sp;
 	char *adkim;
 	char *aspf;
-	unsigned char **rua;
-	unsigned char **ruf;
+	char **rua;
+	char **ruf;
 	DMARC_POLICY_T *dmarc;
 	OPENDMARC_LIB_T lib;
 

--- a/opendmarc/opendmarc-dstring.c
+++ b/opendmarc/opendmarc-dstring.c
@@ -45,7 +45,7 @@ struct dmarcf_dstring
 	int			ds_alloc;
 	int			ds_max;
 	int			ds_len;
-	u_char *		ds_buf;
+	char *		ds_buf;
 };
 
 /*
@@ -68,7 +68,7 @@ static _Bool
 dmarcf_dstring_resize(struct dmarcf_dstring *dstr, int len)
 {
 	int newsz;
-	u_char *new;
+	char *new;
 
 	assert(dstr != NULL);
 	assert(len > 0);
@@ -192,7 +192,7 @@ dmarcf_dstring_free(struct dmarcf_dstring *dstr)
 */
 
 _Bool
-dmarcf_dstring_copy(struct dmarcf_dstring *dstr, u_char *str)
+dmarcf_dstring_copy(struct dmarcf_dstring *dstr, char *str)
 {
 	int len;
 
@@ -235,7 +235,7 @@ dmarcf_dstring_copy(struct dmarcf_dstring *dstr, u_char *str)
 */
 
 _Bool
-dmarcf_dstring_cat(struct dmarcf_dstring *dstr, u_char *str)
+dmarcf_dstring_cat(struct dmarcf_dstring *dstr, char *str)
 {
 	int len;
 
@@ -321,7 +321,7 @@ dmarcf_dstring_cat1(struct dmarcf_dstring *dstr, int c)
 */
 
 _Bool
-dmarcf_dstring_catn(struct dmarcf_dstring *dstr, unsigned char *str,
+dmarcf_dstring_catn(struct dmarcf_dstring *dstr, char *str,
                    size_t nbytes)
 {
 	size_t needed;
@@ -361,7 +361,7 @@ dmarcf_dstring_catn(struct dmarcf_dstring *dstr, unsigned char *str,
 **  	Pointer to the NULL-terminated contents of "dstr".
 */
 
-u_char *
+char *
 dmarcf_dstring_get(struct dmarcf_dstring *dstr)
 {
 	assert(dstr != NULL);

--- a/opendmarc/opendmarc-dstring.h
+++ b/opendmarc/opendmarc-dstring.h
@@ -18,12 +18,12 @@ struct dmarcf_dstring;
 /* PROTOTYPES */
 extern struct dmarcf_dstring *dmarcf_dstring_new __P((int, int));
 extern void dmarcf_dstring_free __P((struct dmarcf_dstring *));
-extern _Bool dmarcf_dstring_copy __P((struct dmarcf_dstring *, u_char *));
-extern _Bool dmarcf_dstring_cat __P((struct dmarcf_dstring *, u_char *));
+extern _Bool dmarcf_dstring_copy __P((struct dmarcf_dstring *, char *));
+extern _Bool dmarcf_dstring_cat __P((struct dmarcf_dstring *, char *));
 extern _Bool dmarcf_dstring_cat1 __P((struct dmarcf_dstring *, int));
-extern _Bool dmarcf_dstring_catn __P((struct dmarcf_dstring *, u_char *, size_t));
+extern _Bool dmarcf_dstring_catn __P((struct dmarcf_dstring *, char *, size_t));
 extern void dmarcf_dstring_chop __P((struct dmarcf_dstring *, int));
-extern u_char *dmarcf_dstring_get __P((struct dmarcf_dstring *));
+extern char *dmarcf_dstring_get __P((struct dmarcf_dstring *));
 extern int dmarcf_dstring_len __P((struct dmarcf_dstring *));
 extern void dmarcf_dstring_blank __P((struct dmarcf_dstring *));
 extern size_t dmarcf_dstring_printf __P((struct dmarcf_dstring *, char *, ...));

--- a/opendmarc/parse.c
+++ b/opendmarc/parse.c
@@ -42,7 +42,7 @@ typedef unsigned long cmap_elem_type;
 #define	CMAP_TST(ar, c)    	((ar)[CMAP_INDEX(c)] &  CMAP_BIT(c))
 #define	CMAP_SET(ar, c)    	((ar)[CMAP_INDEX(c)] |= CMAP_BIT(c))
 
-static unsigned char const SPECIALS[] = "<>@,;:\\\"/[]?=";
+static char const SPECIALS[] = "<>@,;:\\\"/[]?=";
 
 #ifdef MAILPARSE_TEST
 /*
@@ -118,8 +118,8 @@ dmarcf_mail_unescape(char *s)
 **  	everything is balanced.
 */
 
-static u_char *
-dmarcf_mail_matching_paren(u_char *s, u_char *e, int open_paren, int close_paren)
+static char *
+dmarcf_mail_matching_paren(char *s, char *e, int open_paren, int close_paren)
 {
 	int 		paren = 1;
 
@@ -157,11 +157,11 @@ dmarcf_mail_matching_paren(u_char *s, u_char *e, int open_paren, int close_paren
 */
 
 static int
-dmarcf_mail_first_special(u_char *p, u_char *e, u_char **special_out)
+dmarcf_mail_first_special(char *p, char *e, char **special_out)
 {
 	size_t		i;
 	cmap_elem_type	is_special[CMAP_NELEMS] = { 0 };
-	u_char		*at_ptr = NULL;
+	char		*at_ptr = NULL;
 
 	/* set up special finder */
 	for (i = 0; SPECIALS[i] != '\0'; i++)
@@ -228,7 +228,7 @@ dmarcf_mail_first_special(u_char *p, u_char *e, u_char **special_out)
 			while (*p != '\0' &&
 			       !CMAP_TST(is_special, *p) &&
 			       (!isascii(*p) ||
-			        !isspace((unsigned char) *p)) &&
+			        !isspace(*p)) &&
 			       *p != '(')
 				p++;
 			p--;
@@ -256,15 +256,15 @@ dmarcf_mail_first_special(u_char *p, u_char *e, u_char **special_out)
 */
 
 static int
-dmarcf_mail_token(u_char *s, u_char *e, int *type_out, u_char **start_out,
-                  u_char **end_out, int *uncommented_whitespace)
+dmarcf_mail_token(char *s, char *e, int *type_out, char **start_out,
+                  char **end_out, int *uncommented_whitespace)
 {
-	u_char *p;
+	char *p;
 	int err = 0;
 	size_t i;
 	int token_type;
 	cmap_elem_type is_special[CMAP_NELEMS] = { 0 };
-	u_char *token_start, *token_end;
+	char *token_start, *token_end;
 
 	*start_out = NULL;
 	*end_out   = NULL;
@@ -280,8 +280,8 @@ dmarcf_mail_token(u_char *s, u_char *e, int *type_out, u_char **start_out,
 
 	/* skip white space between tokens */
 	while (p < e && (*p == '(' ||
-	                 (isascii((unsigned char) *p) &&
-	                  isspace((unsigned char) *p))))
+	                 (isascii(*p) &&
+	                  isspace(*p))))
 	{
 		if (*p != '(')
 		{
@@ -331,7 +331,7 @@ dmarcf_mail_token(u_char *s, u_char *e, int *type_out, u_char **start_out,
 	else
 	{
 		while (p < e && *p != '\0' && !CMAP_TST(is_special, *p) &&
-		       (!isascii(*p) || !isspace((unsigned char) *p)) &&
+		       (!isascii(*p) || !isspace(*p)) &&
 		       *p != '(')
 			p++;
 
@@ -363,15 +363,15 @@ dmarcf_mail_token(u_char *s, u_char *e, int *type_out, u_char **start_out,
 */
 
 int
-dmarcf_mail_parse(unsigned char *line, unsigned char **user_out,
-                  unsigned char **domain_out)
+dmarcf_mail_parse(char *line, char **user_out,
+                  char **domain_out)
 {
 	int type;
 	int ws;
 	int err;
-	u_char *e, *special;
-	u_char *tok_s, *tok_e;
-	u_char *w;
+	char *e, *special;
+	char *tok_s, *tok_e;
+	char *w;
 
 	*user_out = NULL;
 	*domain_out = NULL;
@@ -493,8 +493,8 @@ dmarcf_mail_parse(unsigned char *line, unsigned char **user_out,
 */
 
 int
-dmarcf_mail_parse_multi(unsigned char *line, unsigned char ***users_out,
-                        unsigned char ***domains_out)
+dmarcf_mail_parse_multi(char *line, char ***users_out,
+                        char ***domains_out)
 {
 	_Bool escaped = FALSE;
 	_Bool quoted = FALSE;
@@ -505,10 +505,10 @@ dmarcf_mail_parse_multi(unsigned char *line, unsigned char ***users_out,
 	int parens = 0;
 	char *p;
 	char *addr;
-	unsigned char **uout = NULL;
-	unsigned char **dout = NULL;
-	unsigned char *u;
-	unsigned char *d;
+	char **uout = NULL;
+	char **dout = NULL;
+	char *u;
+	char *d;
 
 	/* walk the input string looking for unenclosed commas */
 	addr = line;
@@ -562,13 +562,13 @@ dmarcf_mail_parse_multi(unsigned char *line, unsigned char ***users_out,
 
 			if (n == 0)
 			{
-				size_t newsize = 2 * sizeof(unsigned char *);
+				size_t newsize = 2 * sizeof(char *);
 
-				uout = (unsigned char **) malloc(newsize);
+				uout = (char **) malloc(newsize);
 				if (uout == NULL)
 					return -1;
 
-				dout = (unsigned char **) malloc(newsize);
+				dout = (char **) malloc(newsize);
 				if (dout == NULL)
 				{
 					free(uout);
@@ -579,11 +579,11 @@ dmarcf_mail_parse_multi(unsigned char *line, unsigned char ***users_out,
 			}
 			else if (n + 1 == a)
 			{
-				unsigned char **new;
+				char **new;
 
-				size_t newsize = a * 2 * sizeof(unsigned char *);
+				size_t newsize = a * 2 * sizeof(char *);
 
-				new = (unsigned char **) realloc(uout, newsize);
+				new = (char **) realloc(uout, newsize);
 				if (new == NULL)
 				{
 					free(uout);
@@ -593,7 +593,7 @@ dmarcf_mail_parse_multi(unsigned char *line, unsigned char ***users_out,
 
 				uout = new;
 
-				new = (unsigned char **) realloc(dout, newsize);
+				new = (char **) realloc(dout, newsize);
 				if (new == NULL)
 				{
 					free(uout);
@@ -640,7 +640,7 @@ int
 main(int argc, char **argv)
 {
 	int err;
-	unsigned char **domains, **users;
+	char **domains, **users;
 
 	if (argc != 2)
 	{
@@ -658,7 +658,7 @@ main(int argc, char **argv)
 	{
 		int n;
 
-		for (n = 0; domains[n] != (unsigned char *) NULL; n++)
+		for (n = 0; domains[n] != (char *) NULL; n++)
 		{
 			printf("user: '%s'\ndomain: '%s'\n", 
 				string_or_null(users[n]),

--- a/opendmarc/parse.h
+++ b/opendmarc/parse.h
@@ -20,7 +20,7 @@
 #endif /* __STDC__ */
 
 /* prototypes */
-extern int dmarcf_mail_parse __P((unsigned char *, unsigned char **,
-                                  unsigned char **));
+extern int dmarcf_mail_parse __P((char *, char **,
+                                  char **));
 
 #endif /* ! _DMARCF_MAILPARSE_H_ */

--- a/opendmarc/util.c
+++ b/opendmarc/util.c
@@ -243,9 +243,9 @@ dmarcf_socket_cleanup(char *sockspec)
 */
 
 void
-dmarcf_lowercase(u_char *str)
+dmarcf_lowercase(char *str)
 {
-	u_char *p;
+	char *p;
 
 	assert(str != NULL);
 

--- a/opendmarc/util.h
+++ b/opendmarc/util.h
@@ -22,7 +22,7 @@
 
 /* PROTOTYPES */
 extern size_t dmarcf_inet_ntoa __P((struct in_addr, char *, size_t));
-extern void dmarcf_lowercase __P((u_char *));
+extern void dmarcf_lowercase __P((char *));
 extern void dmarcf_optlist __P((FILE *));
 extern void dmarcf_setmaxfd __P((void));
 extern int dmarcf_socket_cleanup __P((char *));


### PR DESCRIPTION
The C Library routines all treat strings as "char *".  Much of the
code here treats them as "unsigned char *" (sometimes by using
"u_char *") which results in the compiler flagging every single
instance as an incompatable pointer assignment.

This patch converts them all to be "char *" following the C
convention.  I chose this approach because it means all of the
string library functions work without casting.

I've reviewed as best I can this does not introduce bugs, but
what's really needed is a test of QA tests to confirm.

Resolves: #108