### PR TITLE
Fix assignment comparsion warning.

### DIFF
--- a/opendmarc/opendmarc-arcares.c
+++ b/opendmarc/opendmarc-arcares.c
@@ -255,7 +255,7 @@ opendmarc_arcares_parse (u_char *hdr, struct arcares *aar)
 		  case AAR_TAG_INSTANCE:
 			aar->instance = atoi(tag_value);
 			/* next value will be unlabeled authserv_id */
-			if (token = strsep((char **) &tmp_ptr, ";"))
+			if ((token = strsep((char **) &tmp_ptr, ";")) != NULL)
 			{
 				leading_space_len = strspn(token, " \n\t");
 				tag_value = opendmarc_arcares_strip_whitespace(token);


### PR DESCRIPTION
GCC warns:
warning: using the result of an assignment as a condition without parentheses [-Wparentheses]

I not only added the parens, but also an explicity comparsion to NULL
here to make it clear what is being checked from the library function.

Full warning output:

```
opendmarc-arcares.c:258:14: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
                        if (token = strsep((char **) &tmp_ptr, ";"))
                            ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
opendmarc-arcares.c:258:14: note: place parentheses around the assignment to silence this warning
                        if (token = strsep((char **) &tmp_ptr, ";"))
                                  ^
                            (                                      )
opendmarc-arcares.c:258:14: note: use '==' to turn this assignment into an equality comparison
                        if (token = strsep((char **) &tmp_ptr, ";"))
                                  ^
                                  ==
1 warning generated.
```