### PR TITLE
Add missing prototype for dmarcf_mail_parse_multi.

### DIFF
--- a/opendmarc/parse.h
+++ b/opendmarc/parse.h
@@ -22,5 +22,8 @@
 /* prototypes */
 extern int dmarcf_mail_parse __P((unsigned char *, unsigned char **,
                                   unsigned char **));
+extern int dmarcf_mail_parse_multi __P((char *, char ***,
+                                       char ***));
+
 
 #endif /* ! _DMARCF_MAILPARSE_H_ */


### PR DESCRIPTION
The function dmarcf_mail_parse_multi in parse.c is missing a prototype
in parse.h resulting in a warning from the compiler.  This adds the
prototype to parse.h.

Full error message:

```
opendmarc.c:2390:11: warning: implicit declaration of function 'dmarcf_mail_parse_multi' is invalid in C99 [-Wimplicit-function-declaration]
        status = dmarcf_mail_parse_multi(addrbuf, &users, &domains);
```