### PR TITLE
Add defines for NETDB_INTERNAL and NETDB_SUCCESS

### DIFF
--- a/libopendmarc/opendmarc_internal.h
+++ b/libopendmarc/opendmarc_internal.h
@@ -101,6 +101,15 @@
 #       define MAYBE		(2)
 # endif 
 # define bool int
+
+#ifndef NETDB_INTERNAL
+# define NETDB_INTERNAL (-1)
+#endif
+
+#ifndef NETDB_SUCCESS
+# define NETDB_SUCCESS (0)
+#endif
+
 /*
 ** Beware that some Linux versions incorrectly define 
 ** MAXHOSTNAMELEN as 64, but DNS lookups require a length


### PR DESCRIPTION
This fixes a compilation issue when using musl libc because these are not defined in its netdb.h.

Closes #129.