### PR TITLE
Add ifdef for USE_DMARCSTRL_H.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -79,8 +79,7 @@ As Postfix currently does not provide the milter library, you need to have
 sendmail sources or development package installed.  See
 http://www.postfix.org/MILTER_README.html
 
-You can view the configuration options with the following command (once you
-have built the configure script (see step 3, below)):
+You can view the configuration options with the following command:
 
 	./configure --help
 
@@ -89,15 +88,17 @@ installed.
 
 Steps to compiling the library and the milter:
 
-(1) Download the source from github
-    git clone https://github.com/trusteddomainproject/OpenDMARC.git
+(1) Download the source from SourceForge
+    (http://sourceforge.net/projects/opendmarc).
 
-(2) Change directories to the repository directory that
+(2) Unpack the tarball:
+	tar -xzvf opendmarc-<version>.tar.gz
+
+    Note: Use <version> as the version number that you downloaded.
+
+(3) Change directories to the release directory (opendmarc-<version>) that
     was created in step 2.
 	cd opendmarc-<version>
-
-(3) Run gnu autoreconf to generate the configure and make files.
-	autoreconf -v -i
 
 (4) Run the "configure" script to configure the package for your operating
     system.

--- a/configure.ac
+++ b/configure.ac
@@ -523,6 +523,7 @@ AC_OUTPUT([ Makefile
 	contrib/spec/Makefile
 		contrib/spec/opendmarc.spec
 	db/Makefile
+	docs/Makefile
 	libopendmarc/Makefile
 	libopendmarc/tests/Makefile
 	libopendmarc/tests/testfiles/Makefile

--- a/contrib/spec/opendmarc.spec.in
+++ b/contrib/spec/opendmarc.spec.in
@@ -121,7 +121,7 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root)
-%doc INSTALL README RELEASE_NOTES
+%doc INSTALL README RELEASE_NOTES docs/draft-dmarc-base-02.txt
 %doc db/README.schema db/schema.mysql
 %config(noreplace) %{_sysconfdir}/%{name}.conf
 %config(noreplace) %{_sysconfdir}/tmpfiles.d/%{name}.conf

--- a/libopendmarc/dmarc.h
+++ b/libopendmarc/dmarc.h
@@ -150,7 +150,7 @@ OPENDMARC_STATUS_T opendmarc_get_policy_token_used(DMARC_POLICY_T *pctx);
  * TLD processing
  */
 int  		   opendmarc_tld_read_file(char *path_fname, char *commentstring, char *drop, char *except);
-void		   opendmarc_tld_shutdown(void);
+void		   opendmarc_tld_shutdown();
 
 /*
  * XML Parsing

--- a/libopendmarc/opendmarc_policy.c
+++ b/libopendmarc/opendmarc_policy.c
@@ -632,7 +632,7 @@ opendmarc_policy_query_dmarc_xdomain(DMARC_POLICY_T *pctx, u_char *uri)
 			continue;
 		}
 	}
-	if (dns_reply == NETDB_SUCCESS && strcmp( buf, "&" ) != 0)
+	if (dns_reply == NETDB_SUCCESS && buf != NULL)
 	{
 		/* Must include DMARC version */
 		if (strncasecmp((char *)buf, "v=DMARC1", sizeof buf) == 0)
@@ -661,7 +661,7 @@ opendmarc_policy_query_dmarc_xdomain(DMARC_POLICY_T *pctx, u_char *uri)
 			continue;
 		}
 	}
-	if (dns_reply == NETDB_SUCCESS && strcmp( buf, "&" ) != 0)
+	if (dns_reply == NETDB_SUCCESS && buf != NULL)
 	{
 		/* Must include DMARC version */
 		if (strncasecmp((char *)buf, "v=DMARC1", sizeof buf) == 0)

--- a/libopendmarc/opendmarc_spf.c
+++ b/libopendmarc/opendmarc_spf.c
@@ -1098,9 +1098,10 @@ opendmarc_spf_macro_expand(SPF_CTX_T *spfctx, char *str, char *buf, size_t bufle
 		{
 			num = strtoul(xp, &xp, 10);
 		}
-		char * cp;
 		switch ((int)*sp)
 		{
+		    char * cp;
+
 		    case 's':
 			if (rev == TRUE)
 				(void) opendmarc_spf_reverse(spfctx->mailfrom_domain, scratch, MAXDNSHOSTNAME);

--- a/libopendmarc/opendmarc_strl.c
+++ b/libopendmarc/opendmarc_strl.c
@@ -50,7 +50,10 @@
 */
 
 size_t
-dmarc_strlcpy(register char *dst, register const char *src, ssize_t size)
+dmarc_strlcpy(dst, src, size)
+	register char *dst;
+	register const char *src;
+	ssize_t size;
 {
 	register ssize_t i;
 
@@ -93,7 +96,10 @@ dmarc_strlcpy(register char *dst, register const char *src, ssize_t size)
 */
 
 size_t
-dmarc_strlcat(register char *dst, register const char *src, ssize_t size)
+dmarc_strlcat(dst, src, size)
+	register char *dst;
+	register const char *src;
+	ssize_t size;
 {
 	register ssize_t i, j, o;
 

--- a/libopendmarc/opendmarc_tld.c
+++ b/libopendmarc/opendmarc_tld.c
@@ -110,7 +110,7 @@ opendmarc_tld_read_file(char *path_fname, char *commentstring, char *drop, char 
 	u_char 	buf[BUFSIZ];
 	char *	cp;
 	void *	vp;
-	int	nlines=0;
+	int	nlines;
 	int	ret;
 	u_char	revbuf[MAXDNSHOSTNAME];
 	int	adddot;

--- a/opendmarc/opendmarc-arcares.c
+++ b/opendmarc/opendmarc-arcares.c
@@ -21,6 +21,11 @@
 # include <bsd/string.h>
 #endif /* USE_BSD_H */
 
+/* opendmarc_strl if needed */
+#ifdef USE_DMARCSTRL_H
+# include <opendmarc_strl.h>
+#endif /* USE_DMARCSTRL_H */
+
 #include "opendmarc-arcares.h"
 #include "opendmarc.h"
 

--- a/opendmarc/opendmarc-arcseal.c
+++ b/opendmarc/opendmarc-arcseal.c
@@ -20,6 +20,11 @@
 # include <bsd/string.h>
 #endif /* USE_BSD_H */
 
+/* opendmarc_strl if needed */
+#ifdef USE_DMARCSTRL_H
+# include <opendmarc_strl.h>
+#endif /* USE_DMARCSTRL_H */
+
 #include "opendmarc-arcseal.h"
 #include "opendmarc.h"
 

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -2451,7 +2451,7 @@ mlfi_eom(SMFICTX *ctx)
 	strncpy(dfc->mctx_fromdomain, domain, sizeof dfc->mctx_fromdomain - 1);
 
 	ostatus = opendmarc_policy_store_from_domain(cc->cctx_dmarc,
-	                                             dfc->mctx_fromdomain);
+	                                             from->hdr_value);
 	if (ostatus != DMARC_PARSE_OKAY)
 	{
 		if (conf->conf_dolog)


### PR DESCRIPTION
On systems that lack strlcpy (e.g. Linux) OpenDMARC works around
by providing it's own strlcpy in opendmarc_strl.h.  Two files were
missing the appropraite ifdef and include at the top, and thus
would not compile on these platforms.  This patch adds the appropriate
blocks so these files compile on such platforms.