### PR TITLE
Fix strncpy bounds violation.

### DIFF
--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -2136,7 +2136,7 @@ mlfi_envfrom(SMFICTX *ctx, char **envfrom)
 
 		p = strchr(dfc->mctx_envfrom, '@');
 		if (p != NULL)
-			strncpy(dfc->mctx_envdomain, p + 1, strlen(p + 1));
+			strlcpy(dfc->mctx_envdomain, p + 1, sizeof(dfc->mctx_envdomain));
 	}
 
 	return SMFIS_CONTINUE;


### PR DESCRIPTION
The code uses the length of the _source_ string as the bounds limit
for the copy into the _desintation_.  This can lead to a buffer
overrun.

Change to use the safer strlcpy that is used elsewhere in the code
bounds limited on the _destination_ size.