### PR TITLE
Domain database case depends on first entry

### DIFF
--- a/reports/opendmarc-import.in
+++ b/reports/opendmarc-import.in
@@ -649,7 +649,7 @@ while (<$inputfh>)
 				}
 
 	  case "from"		{
-					$fdomain = $value;
+					$fdomain = lc($value);
 				}
 
 	  case "job"		{
@@ -691,7 +691,7 @@ while (<$inputfh>)
 				}
 
 	  case "mfrom"		{
-					$envdomain = $value;
+					$envdomain = lc($value);
 				}
 
 	  case "p"		{
@@ -703,7 +703,7 @@ while (<$inputfh>)
 				}
 
 	  case "pdomain"	{
-					$pdomain = $value;
+					$pdomain = lc($value);
 				}
 
 	  case "policy"		{


### PR DESCRIPTION
From SF ticket 204 (https://sourceforge.net/p/opendmarc/tickets/204/) reported and patch provided by Dirk Stoecker:

The first time a domain is received sets the case of the domain name. That's ugly, as the reports then depends on a random spammer mail.
Attached patch fixes the import tool, so that domains are always entered in lower case.