### PR TITLE
Remove variables that are set but not used.

### DIFF
--- a/opendmarc/opendmarc-ar.c
+++ b/opendmarc/opendmarc-ar.c
@@ -359,7 +359,6 @@ ares_xconvert(struct lookup *table, int code)
 int
 ares_parse(u_char *hdr, struct authres *ar)
 {
-	_Bool quoted;
 	int n;
 	int ntoks;
 	int c;
@@ -382,8 +381,6 @@ ares_parse(u_char *hdr, struct authres *ar)
 	prevstate = -1;
 	state = 0;
 	n = 0;
-
-	quoted = FALSE;
 
 	for (c = 0; c < ntoks; c++)
 	{

--- a/opendmarc/opendmarc-arcares.c
+++ b/opendmarc/opendmarc-arcares.c
@@ -110,9 +110,6 @@ opendmarc_arcares_strip_whitespace(u_char *string)
 
 	int a;
 	int b;
-	char *string_ptr;
-
-	string_ptr = string;
 
 	for (a = 0, b = 0;
 	     string[b] != '\0' && b < OPENDMARC_ARCARES_MAX_TOKEN_LEN;

--- a/opendmarc/opendmarc-arcseal.c
+++ b/opendmarc/opendmarc-arcseal.c
@@ -99,9 +99,6 @@ opendmarc_arcseal_strip_whitespace(u_char *string)
 
 	int a;
 	int b;
-	char *string_ptr;
-
-	string_ptr = string;
 
 	for (a = 0, b = 0;
 	     string[b] != '\0' && b < OPENDMARC_ARCSEAL_MAX_TOKEN_LEN;

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -1082,7 +1082,6 @@ dmarcf_checkip(_SOCK_ADDR *ip, struct list *list)
 
 	if (ip->sa_family == AF_INET)
 	{
-		_Bool exists;
 		int c;
 		int bits;
 		struct in_addr addr;
@@ -1091,9 +1090,6 @@ dmarcf_checkip(_SOCK_ADDR *ip, struct list *list)
 
 		memcpy(&sin, ip, sizeof sin);
 		memcpy(&addr.s_addr, &sin.sin_addr, sizeof addr.s_addr);
-
-		/* try the IP address directly */
-		exists = FALSE;
 
 		ipbuf[0] = '!';
 		(void) dmarcf_inet_ntoa(addr, &ipbuf[1], sizeof ipbuf - 1);
@@ -1893,7 +1889,6 @@ sfsistat
 mlfi_connect(SMFICTX *ctx, char *host, _SOCK_ADDR *ip)
 {
 	DMARCF_CONNCTX cc;
-	struct dmarcf_config *conf;
 
 	dmarcf_config_reload();
 
@@ -1932,15 +1927,9 @@ mlfi_connect(SMFICTX *ctx, char *host, _SOCK_ADDR *ip)
 		cc->cctx_config = curconf;
 		curconf->conf_refcnt++;
 
-		conf = curconf;
-
 		pthread_mutex_unlock(&conf_lock);
 
 		dmarcf_setpriv(ctx, cc);
-	}
-	else
-	{
-		conf = cc->cctx_config;
 	}
 
 	if (host != NULL)


### PR DESCRIPTION
gcc 8.3.1 on CentOS 8.3 reports the following variables are set but not used:

```
opendmarc.c: In function ‘dmarcf_checkip’:
opendmarc.c:1085:9: warning: variable ‘exists’ set but not used [-Wunused-but-set-variable]
   _Bool exists;
         ^~~~~~

opendmarc.c: In function ‘mlfi_connect’:
opendmarc.c:1896:24: warning: variable ‘conf’ set but not used [-Wunused-but-set-variable]
  struct dmarcf_config *conf;
                        ^~~~

opendmarc-ar.c: In function ‘ares_parse’:
opendmarc-ar.c:362:8: warning: variable ‘quoted’ set but not used [-Wunused-but-set-variable]
  _Bool quoted;
        ^~~~~~

opendmarc-arcares.c:113:8: warning: variable ‘string_ptr’ set but not used [-Wunused-but-set-variable]
  char *string_ptr;
        ^~~~~~~~~~

opendmarc-arcseal.c: In function ‘opendmarc_arcseal_strip_whitespace’:
opendmarc-arcseal.c:102:8: warning: variable ‘string_ptr’ set but not used [-Wunused-but-set-variable]
  char *string_ptr;
        ^~~~~~~~~~
```

This patch removes all of them after verfing manually that the compiler was correct.