### PR TITLE
Opendmarc SPF repairs and restructure

### DIFF
--- a/libopendmarc/opendmarc_spf.c
+++ b/libopendmarc/opendmarc_spf.c
@@ -273,7 +273,7 @@ opendmarc_spf_status_to_msg(SPF_CTX_T *spfctx, int status)
 		break;
 #define SPF_RETURN_DASH_FORCED_HARD_FAIL    (9)
 	    case SPF_RETURN_DASH_FORCED_HARD_FAIL:
-		r = "Required 'A' bu no 'A' records with -a specified";
+		r = "Required 'A' but no 'A' records with -a specified";
 		break;
 #define SPF_RETURN_A_BUT_BAD_SYNTAX     (10)
 	    case SPF_RETURN_A_BUT_BAD_SYNTAX:
@@ -295,16 +295,16 @@ opendmarc_spf_status_to_msg(SPF_CTX_T *spfctx, int status)
 	    case SPF_RETURN_REDIRECT_NO_DOMAIN:
 		r = "'REDIRECT' Domain Lookup Failed";
 		break;
-#define SPF_RETURN_DASH_ALL_HARD_FAIL   (15)
-	    case SPF_RETURN_DASH_ALL_HARD_FAIL:
+#define SPF_RETURN_FAIL   (15)
+	    case SPF_RETURN_FAIL:
 		r = "Hard Fail: Reject";
 		break;
-#define SPF_RETURN_TILDE_ALL_SOFT_FAIL  (16)
-	    case SPF_RETURN_TILDE_ALL_SOFT_FAIL:
+#define SPF_RETURN_SOFTFAIL  (16)
+	    case SPF_RETURN_SOFTFAIL:
 		r = "Soft Fail: Subject to Policy";
 		break;
-#define SPF_RETURN_QMARK_ALL_NEUTRAL    (17)
-	    case SPF_RETURN_QMARK_ALL_NEUTRAL:
+#define SPF_RETURN_NEUTRAL    (17)
+	    case SPF_RETURN_NEUTRAL:
 		r = "Neutral Fail: Subject to Policy";
 		break;
 #define SPF_RETURN_UNKNOWN_KEYWORD      (18)
@@ -395,13 +395,13 @@ opendmarc_spf_status_to_pass(int status, int none_pass)
 	    case SPF_RETURN_REDIRECT_NO_DOMAIN:
 		r = 0;
 		break;
-	    case SPF_RETURN_DASH_ALL_HARD_FAIL:
+	    case SPF_RETURN_FAIL:
 		r = 0;
 		break;
-	    case SPF_RETURN_TILDE_ALL_SOFT_FAIL:
+	    case SPF_RETURN_SOFTFAIL:
 		r = -1;
 		break;
-	    case SPF_RETURN_QMARK_ALL_NEUTRAL:
+	    case SPF_RETURN_NEUTRAL:
 		r = 1;
 		break;
 	    case SPF_RETURN_UNKNOWN_KEYWORD:
@@ -1280,6 +1280,9 @@ typedef struct {
 	char *sp;
 	char *ep;
 	char *esp;
+	char redirect[MAXDNSHOSTNAME];
+	char prefix;
+	int result;
 } SPF_STACK_T;
 
 #define SPF_SP  (stack[s].sp)
@@ -1293,7 +1296,6 @@ opendmarc_spf_parse(SPF_CTX_T *spfctx, int dns_count, char *xbuf, size_t xbuf_le
 	char *vp	= NULL;
 	int   i;
 	size_t len;
-	int	prefix;
 	u_long ip	= 0;
 	int split	= 0;
 #define SPLIT_COLON (1)
@@ -1352,6 +1354,7 @@ opendmarc_spf_parse(SPF_CTX_T *spfctx, int dns_count, char *xbuf, size_t xbuf_le
 	SPF_SP  = stack[s].spf;
 	SPF_EP  = stack[s].spf + strlen(stack[s].spf);
 	SPF_ESP = stack[s].spf - 1;
+	stack[s].result = SPF_RETURN_UNDECIDED;
 	up = TRUE;
 
 	while (s >= 0)
@@ -1372,45 +1375,160 @@ opendmarc_spf_parse(SPF_CTX_T *spfctx, int dns_count, char *xbuf, size_t xbuf_le
 				PUSHLINE
 				return spfctx->status = SPF_RETURN_TOO_MANY_DNS_QUERIES;
 			}
-			if (SPF_ESP >= SPF_EP-1)
-			{
-				--s;
-				up = FALSE;
-				break;
-			}
-			SPF_SP = SPF_ESP + 1;
 
-			while (isspace((int)*SPF_SP) && *SPF_SP != '\0' && SPF_SP < SPF_EP)
-				++SPF_SP;
-			if (*SPF_SP == '\0' || SPF_SP >= SPF_EP)
-			{
-				--s;
-				up = FALSE;
-				break;
+			if (stack[s].result != SPF_RETURN_UNDECIDED) {
+
+				/* apply qualifier if we had a match or error in the last iteration */
+				switch (stack[s].result) {
+					/* on match, check qualfier */
+					case SPF_RETURN_OK_PASSED:
+						switch(stack[s].prefix) {
+							case '~':
+								strlcat_multi(xbuf, xbuf_len, " (qualifier '~') --> ", s == 0 ? "SOFTFAIL" : "NOMATCH");
+								stack[s].result = SPF_RETURN_SOFTFAIL;
+								break;
+							case '-':
+								strlcat_multi(xbuf, xbuf_len, " (qualifier '-') --> ", s == 0 ? "FAIL" : "NOMATCH");
+								stack[s].result = SPF_RETURN_FAIL;
+								break;
+							case '?':
+								strlcat_multi(xbuf, xbuf_len, " (qualifier '?') --> ", s == 0 ? "NEUTRAL" : "NOMATCH");
+								stack[s].result = SPF_RETURN_NEUTRAL;
+								break;
+							case '+':
+							case '\0':
+								strlcat_multi(xbuf, xbuf_len, " (qualifier ", stack[s].result == '\0' ? "<none>" : "'+'", ") --> ", s == 0 ? "PASS" : "MATCH");
+								stack[s].result = SPF_RETURN_OK_PASSED;
+								break;
+						}
+				}
+
+				/* evaluate result in context of an include:
+				 *   pass -> "match"; also apply qualifiers of the include,
+				 *   fail/neutral/softfail -> "nomatch",
+				 *   tmperror -> tmperror,
+				 *   permerror -> permerror
+				 **/
+				while (s > 0 && stack[s].result != SPF_RETURN_UNDECIDED) {
+					int result = stack[s].result;
+					s--;
+					up = FALSE;
+					switch (result) {
+						case SPF_RETURN_OK_PASSED:
+							switch(stack[s].prefix) {
+								case '~':
+									(void) strlcat(xbuf, " include: SOFTFAIL", xbuf_len);
+									stack[s].result = SPF_RETURN_SOFTFAIL;
+									break;
+								case '-':
+									(void) strlcat(xbuf, " include: FAIL", xbuf_len);
+									stack[s].result = SPF_RETURN_FAIL;
+									break;
+								case '?':
+									(void) strlcat(xbuf, " include: NEUTRAL", xbuf_len);
+									stack[s].result = SPF_RETURN_NEUTRAL;
+									break;
+								case '+':
+								case '\0':
+									(void) strlcat(xbuf, " include: PASS", xbuf_len);
+									stack[s].result = SPF_RETURN_OK_PASSED;
+									break;
+								default:
+									(void) strlcat(xbuf, " include: INTERNAL ERROR", xbuf_len);
+									stack[s].result = SPF_RETURN_INTERNAL_ERROR;
+									break;
+							}
+							break;
+						case SPF_RETURN_FAIL:
+						case SPF_RETURN_SOFTFAIL:
+						case SPF_RETURN_NEUTRAL:
+							(void) strlcat(xbuf, " include: NOMATCH", xbuf_len);
+							/* "no match" --> do not change the UNDECIDED result
+							 *  and continue processing where the include left off */
+							break;
+						default:
+							/* all other error (!) cases (temperror/permerror) are directly returned as they are */
+							(void) strlcat(xbuf, " include: PROPAGATE ERROR", xbuf_len);
+							stack[s].result = result;
+              break;
+					}
+				}
+
+				/* if we have a result at the toplevel, return it, otherwise,
+				 * continue where we stopped */
+				if (s == 0 && stack[s].result != SPF_RETURN_UNDECIDED) {
+					PUSHLINE
+					return spfctx->status = stack[s].result;
+				}
 			}
 
-			/* find the next space delimit point */
-			SPF_ESP = SPF_SP;
-			while(! isspace((int)*SPF_ESP) && *SPF_ESP != '\0' && SPF_ESP < SPF_EP)
-				++SPF_ESP;
-			if (SPF_ESP > SPF_EP)
-			{
-				--s;
-				up = FALSE;
-				break;
+			int reached_end = FALSE;
+			if (SPF_ESP >= SPF_EP-1) {
+				reached_end = TRUE;
+			} else {
+				SPF_SP = SPF_ESP + 1;
+				while (isspace((int)*SPF_SP) && *SPF_SP != '\0' && SPF_SP < SPF_EP)
+					++SPF_SP;
+				if (*SPF_SP == '\0' || SPF_SP >= SPF_EP) {
+					reached_end = TRUE;
+				} else {
+					SPF_ESP = SPF_SP;
+					while(! isspace((int)*SPF_ESP) && *SPF_ESP != '\0' && SPF_ESP < SPF_EP)
+						++SPF_ESP;
+					if (SPF_ESP > SPF_EP) {
+						reached_end = TRUE;
+					} else {
+						*SPF_ESP = '\0';
+					}
+				}
 			}
-			*SPF_ESP = '\0';
+
+			if (reached_end) {
+				if (stack[s].redirect[0] != '\0') {
+					char *  spf_ret;
+					char	spfbuf[SPF_MAX_SPF_RECORD_LEN];
+					char	cname[MAXDNSHOSTNAME];
+					int	reply;
+					/* redirect */
+					spf_ret = opendmarc_spf_dns_get_record(stack[s].redirect, &reply, spfbuf, sizeof spfbuf, cname, sizeof cname, TRUE);
+					if (spf_ret == NULL)
+					{
+						strlcat_multi(xbuf, xbuf_len, vp, " lacked an SPF record: FAILED");
+						PUSHLINE
+						stack[s].result = SPF_RETURN_BAD_SYNTAX_REDIRECT;
+					}
+					else
+					{
+						(void) memset(stack[s].domain, '\0', MAXDNSHOSTNAME);
+						(void) strlcpy(stack[s].domain, stack[s].redirect, MAXDNSHOSTNAME);
+						(void) memset(stack[s].spf, '\0', SPF_MAX_SPF_RECORD_LEN);
+						(void) strlcpy(stack[s].spf, spfbuf, SPF_MAX_SPF_RECORD_LEN);
+						SPF_SP  = stack[s].spf;
+						SPF_EP  = stack[s].spf + strlen(stack[s].spf);
+						SPF_ESP = stack[s].spf - 1;
+						stack[s].result = SPF_RETURN_UNDECIDED;
+						up = TRUE;
+
+						/* start parsing loop from beginning */
+						break;
+					}
+				} else {
+					--s;
+					up = FALSE;
+					break;
+				}
+			}
 
 			/* show each step */
 			(void) memset(xbuf, '\0', xbuf_len);
 			(void) strlcpy(xbuf, stack[s].domain, xbuf_len);
 			(void) strlcat(xbuf, ": ", xbuf_len);
 
-			/* ignore the qualifiers for now */
-			prefix = '\0';
+			/* remember current qualifier for next iteration to decide handling of a MATCH */
+			stack[s].prefix = '\0';
 			if (*SPF_SP == '+' || *SPF_SP == '?' || *SPF_SP == '~' || *SPF_SP == '-')
 			{
-				prefix = *SPF_SP;
+				stack[s].prefix = *SPF_SP;
 				++SPF_SP;
 			}
 
@@ -1451,15 +1569,14 @@ opendmarc_spf_parse(SPF_CTX_T *spfctx, int dns_count, char *xbuf, size_t xbuf_le
 				{
 					(void) strlcat(xbuf, " Expected \"v=spf1\": FAILED", xbuf_len);
 					PUSHLINE
-					return spfctx->status = SPF_RETURN_BAD_SYNTAX_VERSION;
+					stack[s].result = SPF_RETURN_BAD_SYNTAX_VERSION;
 				}
-				/* version was okay */
-				continue;
 			}
-			if (strncasecmp(SPF_SP, "spf2.0", 6) == 0)
-				continue;
-
-			if (strcasecmp("a", SPF_SP) == 0 || strcasecmp("ip4", SPF_SP) == 0)
+			else if (strncasecmp(SPF_SP, "spf2.0", 6) == 0)
+			{
+				/* accept deprecated syntax */
+			}
+			else if (strcasecmp("a", SPF_SP) == 0 || strcasecmp("ip4", SPF_SP) == 0)
 			{
 				char **	ary = NULL;
 				int	ary_len = 0;
@@ -1479,7 +1596,8 @@ opendmarc_spf_parse(SPF_CTX_T *spfctx, int dns_count, char *xbuf, size_t xbuf_le
 					ary = opendmarc_spf_dns_lookup_a(stack[s].domain, ary, &ary_len);
 					if (ary != NULL)
 					{
-						for (app = ary; *app != NULL; ++app)
+						int match = FALSE;
+						for (app = ary; *app != NULL && !match; ++app)
 						{
 							(void) memset(abuf, '\0', sizeof abuf);
 							(void) strlcpy(abuf, *app, sizeof abuf);
@@ -1490,24 +1608,22 @@ opendmarc_spf_parse(SPF_CTX_T *spfctx, int dns_count, char *xbuf, size_t xbuf_le
 							spfctx->iplist = opendmarc_util_pushnargv(abuf, spfctx->iplist, &(spfctx->ipcount));
 							if (opendmarc_spf_cidr_address(ip, abuf) == TRUE)
 							{
-								strlcat_multi(xbuf, xbuf_len, " ", ipnum, " was found in ", abuf, ": PASSED");
-								PUSHLINE
+								strlcat_multi(xbuf, xbuf_len, " ", ipnum, " was found in ", abuf, ": MATCH");
 								ary = opendmarc_util_freenargv(ary, &ary_len);
-								return spfctx->status = SPF_RETURN_OK_PASSED;
+								stack[s].result = SPF_RETURN_OK_PASSED;
+								match = TRUE;
 							}
 						}
 						ary = opendmarc_util_freenargv(ary, &ary_len);
-						continue;
 					}
-					strlcat_multi(xbuf, xbuf_len, " ", stack[s].domain, " had no A records: FAILED");
-					if (s == 0 && prefix == '-')
+					else
 					{
-						return spfctx->status = SPF_RETURN_DASH_FORCED_HARD_FAIL;
+						strlcat_multi(xbuf, xbuf_len, " ", stack[s].domain, " had no A records: FAILED");
+						PUSHLINE
+						stack[s].result = SPF_RETURN_A_BUT_NO_A_RECORD;
 					}
-					PUSHLINE
-					return spfctx->status = SPF_RETURN_A_BUT_NO_A_RECORD;
 				}
-				if (strcasecmp("a", SPF_SP) == 0 && vp != NULL)
+				else if (strcasecmp("a", SPF_SP) == 0 && vp != NULL)
 				{
 					char *  slashp  = NULL;
 					char ** a_ary   = NULL;
@@ -1520,61 +1636,51 @@ opendmarc_spf_parse(SPF_CTX_T *spfctx, int dns_count, char *xbuf, size_t xbuf_le
 					if (a_ary == NULL)
 					{
 						strlcat_multi(xbuf, xbuf_len, " ", vp, "had no A records: FAILED");
-						if (s == 0 && prefix == '-')
-						{
-							return spfctx->status = SPF_RETURN_DASH_FORCED_HARD_FAIL;
-						}
 						PUSHLINE
-						return spfctx->status = SPF_RETURN_A_BUT_NO_A_RECORD;
+						stack[s].result = SPF_RETURN_A_BUT_NO_A_RECORD;
 					}
-
-					for (a_app = a_ary; *a_app != NULL; ++a_app)
+					else
 					{
-						(void) memset(a_abuf, '\0', sizeof a_abuf);
-						(void) strlcpy(a_abuf, *a_app, sizeof a_abuf);
-						if (slashp != NULL)
+						int match = FALSE;
+						for (a_app = a_ary; *a_app != NULL && !match; ++a_app)
 						{
-							strlcat_multi(a_abuf, sizeof a_abuf, "/", slashp+1);
+							(void) memset(a_abuf, '\0', sizeof a_abuf);
+							(void) strlcpy(a_abuf, *a_app, sizeof a_abuf);
+							if (slashp != NULL)
+							{
+								strlcat_multi(a_abuf, sizeof a_abuf, "/", slashp+1);
+							}
+							spfctx->iplist = opendmarc_util_pushnargv(a_abuf, spfctx->iplist, &(spfctx->ipcount));
+							if (opendmarc_spf_cidr_address(ip, a_abuf) == TRUE)
+							{
+								strlcat_multi(xbuf, xbuf_len, " ", ipnum, " was found: MATCH");
+								a_ary = opendmarc_util_freenargv(a_ary, &ary_len);
+								stack[s].result = SPF_RETURN_OK_PASSED;
+								match = TRUE;
+							}
 						}
-						spfctx->iplist = opendmarc_util_pushnargv(a_abuf, spfctx->iplist, &(spfctx->ipcount));
-						if (opendmarc_spf_cidr_address(ip, a_abuf) == TRUE)
-						{
-							strlcat_multi(xbuf, xbuf_len, " ", ipnum, " was found: PASSED");
-							PUSHLINE
-							a_ary = opendmarc_util_freenargv(a_ary, &ary_len);
-							return spfctx->status = SPF_RETURN_OK_PASSED;
-						}
-						if (s == 0 && prefix == '-')
-						{
-							return spfctx->status = SPF_RETURN_DASH_FORCED_HARD_FAIL;
-						}
+						a_ary = opendmarc_util_freenargv(a_ary, &ary_len);
 					}
-					a_ary = opendmarc_util_freenargv(a_ary, &ary_len);
-					continue;
 				}
-				if (strcasecmp("ip4", SPF_SP) == 0 && vp != NULL)
+				else if (strcasecmp("ip4", SPF_SP) == 0 && vp != NULL)
 				{
 					spfctx->iplist = opendmarc_util_pushnargv(vp, spfctx->iplist, &(spfctx->ipcount));
 					ret = opendmarc_spf_cidr_address(ip, vp);
 					if (ret == TRUE)
 					{
-						strlcat_multi(xbuf, xbuf_len, " ", ipnum, " was found: PASSED");
-						PUSHLINE
-						return spfctx->status = SPF_RETURN_OK_PASSED;
+						strlcat_multi(xbuf, xbuf_len, " ", ipnum, " was found: MATCH");
+						stack[s].result = SPF_RETURN_OK_PASSED;
 					}
-					if (s == 0 && prefix == '-')
-					{
-						return spfctx->status = SPF_RETURN_DASH_FORCED_HARD_FAIL;
-					}
-					continue;
 				}
-				if (vp == NULL)
+				else if (vp == NULL)
+				{
 					vp = "<nil>";
-				strlcat_multi(xbuf, xbuf_len, " ", vp, " Badly formed: FAILED");
-				PUSHLINE
-				return spfctx->status = SPF_RETURN_A_BUT_BAD_SYNTAX;
+					strlcat_multi(xbuf, xbuf_len, " ", vp, " Badly formed: FAILED");
+					PUSHLINE
+					stack[s].result = SPF_RETURN_A_BUT_BAD_SYNTAX;
+				}
 			}
-			if (strcasecmp("mx", SPF_SP) == 0)
+			else if (strcasecmp("mx", SPF_SP) == 0)
 			{
 				char **	ary = NULL;
 				int	ary_len = 0;
@@ -1590,146 +1696,106 @@ opendmarc_spf_parse(SPF_CTX_T *spfctx, int dns_count, char *xbuf, size_t xbuf_le
 				if (ary == NULL)
 				{
 					strlcat_multi(xbuf, xbuf_len, mxbuf, ": MX listed but no MX records");
-					if (s == 0 && prefix == '-')
-					{
-						return spfctx->status = SPF_RETURN_DASH_FORCED_HARD_FAIL;
-					}
 					PUSHLINE
-					continue;
 				}
-				for (app = ary; *app != NULL; ++app)
+				else
 				{
-					spfctx->iplist = opendmarc_util_pushnargv(*app, spfctx->iplist, &(spfctx->ipcount));
-					if (opendmarc_spf_cidr_address(ip, *app) == TRUE)
+					int match = FALSE;
+					for (app = ary; *app != NULL && !match; ++app)
 					{
-						strlcat_multi(xbuf, xbuf_len, " ", ipnum, " was found: PASSED");
-						PUSHLINE
-						ary = opendmarc_util_freenargv(ary, &ary_len);
-						return spfctx->status = SPF_RETURN_OK_PASSED;
+						spfctx->iplist = opendmarc_util_pushnargv(*app, spfctx->iplist, &(spfctx->ipcount));
+						if (opendmarc_spf_cidr_address(ip, *app) == TRUE)
+						{
+							strlcat_multi(xbuf, xbuf_len, " ", ipnum, " was found in MX record: MATCH");
+							ary = opendmarc_util_freenargv(ary, &ary_len);
+							stack[s].result = SPF_RETURN_OK_PASSED;
+							match = TRUE;
+						}
 					}
+					ary = opendmarc_util_freenargv(ary, &ary_len);
 				}
-				ary = opendmarc_util_freenargv(ary, &ary_len);
-				if (s == 0 && prefix == '-')
-				{
-					return spfctx->status = SPF_RETURN_DASH_FORCED_HARD_FAIL;
-				}
-				continue;
 			}
-			if (strcasecmp("include", SPF_SP) == 0)
+			else if (strcasecmp("include", SPF_SP) == 0)
 			{
 				char	*spf_ret;
-				char	spfbuf[SPF_MAX_SPF_RECORD_LEN];
-				char	cname[MAXDNSHOSTNAME];
 				char	query[MAXDNSHOSTNAME];
 				int	reply;
+				char	cname[128];
+				char	spfbuf[BUFSIZ];
 
 				if (vp == NULL || strlen(vp) == 0)
 				{
 					(void) strlcat(xbuf, "\"include:\" Lacked a domain specification.", xbuf_len);
-					if (s == 0 && prefix == '-')
-					{
-						return spfctx->status = SPF_RETURN_DASH_FORCED_HARD_FAIL;
-					}
 					PUSHLINE
-					return spfctx->status = SPF_RETURN_BAD_SYNTAX_INCLUDE;
+					stack[s].result = SPF_RETURN_BAD_SYNTAX_INCLUDE;
 				}
-				(void) memset(query, '\0', sizeof query);
-				(void) strlcpy(query, vp, sizeof query);
-				(void) memset(cname, '\0', sizeof cname);
-				(void) memset(spfbuf, '\0', sizeof spfbuf);
-				++dns_count;
-				spf_ret = opendmarc_spf_dns_get_record(query, &reply, spfbuf, sizeof spfbuf, cname, sizeof cname, TRUE);
-				if (spf_ret == NULL)
+				else
 				{
-					strlcat_multi(xbuf, xbuf_len, vp, " lacked an SPF record: FAILED");
-					if (s == 0 && prefix == '-')
+					(void) memset(query, '\0', sizeof query);
+					(void) strlcpy(query, vp, sizeof query);
+					(void) memset(cname, '\0', sizeof cname);
+					(void) memset(spfbuf, '\0', sizeof spfbuf);
+					++dns_count;
+					spf_ret = opendmarc_spf_dns_get_record(query, &reply, spfbuf, sizeof spfbuf, cname, sizeof cname, TRUE);
+					if (spf_ret == NULL)
 					{
-						return spfctx->status = SPF_RETURN_DASH_FORCED_HARD_FAIL;
-					}
-					PUSHLINE
-					return spfctx->status = SPF_RETURN_INCLUDE_NO_DOMAIN;
-				}
-				if (s+1 >= MAX_SPF_STACK_DEPTH)
-				{
-					char nbuf[16];
-					(void) opendmarc_util_ultoa(MAX_SPF_STACK_DEPTH, nbuf, sizeof nbuf);
-					strlcat_multi(xbuf, xbuf_len, stack[s].domain, " Too many levels of includes, ", nbuf, " Max");
-					if (s == 0 && prefix == '-')
-					{
-						return spfctx->status = SPF_RETURN_DASH_FORCED_HARD_FAIL;
-					}
-					PUSHLINE
-					continue;
-				}
-				if (s > 0)
-				{
-					for (i = 0; i < s; i++)
-					{
-						if (strcasecmp(vp, stack[i].domain) == 0)
-							break;
-					}
-					if (i < s)
-					{
-						strlcat(xbuf, xbuf_len, query, " Include LOOP detected and suppressed");
+						strlcat_multi(xbuf, xbuf_len, vp, " lacked an SPF record: FAILED");
 						PUSHLINE
-						continue;
+						stack[s].result = SPF_RETURN_INCLUDE_NO_DOMAIN;
 					}
-				}
-				s += 1;
-				up = TRUE;
-				(void) memset(stack[s].domain, '\0', MAXDNSHOSTNAME);
-				(void) strlcpy(stack[s].domain, vp, MAXDNSHOSTNAME);
-				(void) memset(stack[s].spf, '\0', SPF_MAX_SPF_RECORD_LEN);
-				(void) strlcpy(stack[s].spf, spfbuf, SPF_MAX_SPF_RECORD_LEN);
-				SPF_SP  = stack[s].spf;
-				SPF_EP  = stack[s].spf + strlen(stack[s].spf);
-				SPF_ESP = stack[s].spf - 1;
-				if (s == 0 && prefix == '-')
-				{
-					return spfctx->status = SPF_RETURN_DASH_FORCED_HARD_FAIL;
-				}
-				break;
-			}
-			if (strcasecmp("all", SPF_SP) == 0)
-			{
-				char p[2];
-
-				p[0] = prefix;
-				p[1] = '\0';
-				(void) memset(xbuf, '\0', xbuf_len);
-				(void) strlcpy(xbuf, stack[s].domain, xbuf_len);
-				strlcat_multi(xbuf, xbuf_len, ": ", p, "all, status=");
-
-				if (s == 0)
-				{
-					if (prefix == '-')
+					else if (s+1 >= MAX_SPF_STACK_DEPTH)
 					{
-						strlcat_multi(xbuf, xbuf_len, " ", ipnum, " Not found, so: FAILED");
+						char nbuf[16];
+						(void) opendmarc_util_ultoa(MAX_SPF_STACK_DEPTH, nbuf, sizeof nbuf);
+						strlcat_multi(xbuf, xbuf_len, stack[s].domain, " Too many levels of includes, ", nbuf, " Max");
 						PUSHLINE
-						return spfctx->status = SPF_RETURN_DASH_ALL_HARD_FAIL;
-					}
-					if (prefix == '~')
-					{
-						strlcat_multi(xbuf, xbuf_len, " ", ipnum, " Not found, so: SOFT-FAILED");
-						PUSHLINE
-						return spfctx->status = SPF_RETURN_TILDE_ALL_SOFT_FAIL;
-					}
-					if (prefix == '?')
-					{
-						strlcat_multi(xbuf, xbuf_len, " ", ipnum, " Not found, but: NEUTRAL");
-						PUSHLINE
-						return spfctx->status = SPF_RETURN_QMARK_ALL_NEUTRAL;
 					}
 					else
 					{
-						strlcat_multi(xbuf, xbuf_len, " ", ipnum, " Not found, but: PASS");
-						PUSHLINE
-						return spfctx->status = SPF_RETURN_OK_PASSED;
+						i = 0;
+						if (s > 0) {
+							for (i = 0; i < s; i++)
+							{
+								if (strcasecmp(vp, stack[i].domain) == 0)
+									break;
+							}
+						}
+
+						if (i < s)
+						{
+							strlcat_multi(xbuf, xbuf_len, query, " Include LOOP detected and suppressed");
+							PUSHLINE
+						}
+						else
+						{
+							s += 1;
+							up = TRUE;
+							(void) memset(stack[s].domain, '\0', MAXDNSHOSTNAME);
+							(void) strlcpy(stack[s].domain, vp, MAXDNSHOSTNAME);
+							(void) memset(stack[s].spf, '\0', SPF_MAX_SPF_RECORD_LEN);
+							(void) strlcpy(stack[s].spf, spfbuf, SPF_MAX_SPF_RECORD_LEN);
+							(void) memset(stack[s].redirect, '\0', MAXDNSHOSTNAME);
+							SPF_SP  = stack[s].spf;
+							SPF_EP  = stack[s].spf + strlen(stack[s].spf);
+							SPF_ESP = stack[s].spf - 1;
+							stack[s].prefix = '\0';
+							stack[s].result = SPF_RETURN_UNDECIDED;
+
+							/* break out of inner record-parsing loop */
+							break;
+						}
 					}
 				}
-				continue;
 			}
-			if (strcasecmp("ip6", SPF_SP) == 0)
+			else if (strcasecmp("all", SPF_SP) == 0)
+			{
+
+				(void) memset(xbuf, '\0', xbuf_len);
+				(void) strlcpy(xbuf, stack[s].domain, xbuf_len);
+				strlcat_multi(xbuf, xbuf_len, ": ", ipnum, " matched by all: MATCH");
+				stack[s].result = SPF_RETURN_OK_PASSED;
+			}
+			else if (strcasecmp("ip6", SPF_SP) == 0)
 			{
 				int ret;
 				/*
@@ -1740,30 +1806,22 @@ opendmarc_spf_parse(SPF_CTX_T *spfctx, int dns_count, char *xbuf, size_t xbuf_le
 				ret = opendmarc_spf_ipv6_cidr_check(spfctx->ip_address, vp);
 				if (ret == TRUE)
 				{
-					return spfctx->status = SPF_RETURN_OK_PASSED;
+					strlcat_multi(xbuf, xbuf_len, " ", ipnum, " was found: MATCH");
+					stack[s].result = spfctx->status = SPF_RETURN_OK_PASSED;
 				}
-				if (s == 0 && prefix == '-')
-				{
-					return spfctx->status = SPF_RETURN_DASH_FORCED_HARD_FAIL;
-				}
-				continue;
 			}
-			if (strcasecmp("ptr", SPF_SP) == 0)
+			else if (strcasecmp("ptr", SPF_SP) == 0)
 			{
 				int	good;
 
 				good = opendmarc_spf_ptr_domain(spfctx, vp);
 				if (good == TRUE)
 				{
-					return spfctx->status = SPF_RETURN_OK_PASSED;
+					strlcat_multi(xbuf, xbuf_len, ": ", ipnum, " matches ptr: ", vp, ": MATCH");
+					stack[s].result = SPF_RETURN_OK_PASSED;
 				}
-				if (s == 0 && prefix == '-')
-				{
-					return spfctx->status = SPF_RETURN_DASH_FORCED_HARD_FAIL;
-				}
-				continue;
 			}
-			if (strcasecmp("exists", SPF_SP) == 0)
+			else if (strcasecmp("exists", SPF_SP) == 0)
 			{
 				char *	xp;
 				char **	ary	 = NULL;
@@ -1774,41 +1832,45 @@ opendmarc_spf_parse(SPF_CTX_T *spfctx, int dns_count, char *xbuf, size_t xbuf_le
 				{
 					(void) strlcpy(xbuf, "\"exists:\" Lacked a domain specification.", xbuf_len);
 					PUSHLINE
-					return spfctx->status = SPF_RETURN_BAD_SYNTAX_EXISTS;
+					stack[s].result = SPF_RETURN_BAD_SYNTAX_EXISTS;
 				}
-				/* see http://old.openspf.org/macros.html for macros */
-				/* altavista.net uses +exists:CL.%{i}.FR.%{s}.HE.%{h}.null.spf.altavista.com */
-				xp = opendmarc_spf_macro_expand(spfctx, vp, xbuf, xbuf_len, TRUE);
-				if (xp == NULL)
+				else
 				{
-					(void) strlcpy(xbuf, "\"exists:\" record had syntactially bad macros:" , xbuf_len);
-					strlcat_multi(xbuf, xbuf_len, vp, ": FAILED");
-					PUSHLINE
-					return spfctx->status = SPF_RETURN_BAD_MACRO_SYNTAX;
+					/* see http://old.openspf.org/macros.html for macros */
+					/* altavista.net uses +exists:CL.%{i}.FR.%{s}.HE.%{h}.null.spf.altavista.com */
+					xp = opendmarc_spf_macro_expand(spfctx, vp, xbuf, xbuf_len, TRUE);
+					if (xp == NULL)
+					{
+						(void) strlcpy(xbuf, "\"exists:\" record had syntactially bad macros:" , xbuf_len);
+						strlcat_multi(xbuf, xbuf_len, vp, ": FAILED");
+						PUSHLINE
+						stack[s].result = SPF_RETURN_BAD_MACRO_SYNTAX;
+					}
+					else
+					{
+						++dns_count;
+						if (ary != NULL)
+							ary = opendmarc_util_freenargv(ary, &ary_len);
+						ary = opendmarc_spf_dns_lookup_a(xbuf, ary, &ary_len);
+						if (ary != NULL)
+						{
+							int match = FALSE;
+							for (app = ary; *app != NULL && !match; ++app)
+							{
+								if (strcmp(spfctx->ip_address, *app) == 0)
+								{
+									(void) strlcpy(xbuf, "\"exists:\" record lookup: ", xbuf_len);
+									strlcat_multi(xbuf, xbuf_len, vp, " existed: MATCH");
+									stack[s].result = SPF_RETURN_OK_PASSED;
+									match = TRUE;
+								}
+							}
+							ary = opendmarc_util_freenargv(ary, &ary_len);
+						}
+					}
 				}
-				++dns_count;
-				if (ary != NULL)
-					ary = opendmarc_util_freenargv(ary, &ary_len);
-				ary = opendmarc_spf_dns_lookup_a(xbuf, ary, &ary_len);
-				if (ary == NULL)
-				{
-					/* lookup failed */
-					if (prefix != '-')
-						continue;
-					(void) strlcpy(xbuf, "\"exists:\" record lookup: ", xbuf_len);
-					strlcat_multi(xbuf, xbuf_len, vp, ": FAILED");
-					PUSHLINE
-					return spfctx->status = SPF_RETURN_NOT_EXISTS_HARDFAIL;
-				}
-				for (app = ary; *app != NULL; ++app)
-				{
-					if (strcmp(spfctx->ip_address, *app) == 0)
-						return spfctx->status = SPF_RETURN_OK_PASSED;
-				}
-				ary = opendmarc_util_freenargv(ary, &ary_len);
-				continue;
 			}
-			if (strcasecmp("exp", SPF_SP) == 0)
+			else if (strcasecmp("exp", SPF_SP) == 0)
 			{
 				char *	xp;
 
@@ -1816,78 +1878,65 @@ opendmarc_spf_parse(SPF_CTX_T *spfctx, int dns_count, char *xbuf, size_t xbuf_le
 				{
 					(void) strlcpy(xbuf, "\"exp:\" Lacked a domain specification.", xbuf_len);
 					PUSHLINE
-					return spfctx->status = SPF_RETURN_BAD_SYNTAX_EXP;
+					stack[s].result = SPF_RETURN_BAD_SYNTAX_EXP;
 				}
-				xp = opendmarc_spf_macro_expand(spfctx, vp, xbuf, xbuf_len, FALSE);
-				if (xp == NULL)
+				else
 				{
-					(void) strlcpy(xbuf, "\"exists:\" record had syntactially bad macros:" , xbuf_len);
-					strlcat_multi(xbuf, xbuf_len, vp, ": FAILED");
-					PUSHLINE
-					return spfctx->status = SPF_RETURN_BAD_MACRO_SYNTAX;
+					xp = opendmarc_spf_macro_expand(spfctx, vp, xbuf, xbuf_len, FALSE);
+					if (xp == NULL)
+					{
+						(void) strlcpy(xbuf, "\"exists:\" record had syntactially bad macros:" , xbuf_len);
+						strlcat_multi(xbuf, xbuf_len, vp, ": FAILED");
+						PUSHLINE
+						stack[s].result = SPF_RETURN_BAD_MACRO_SYNTAX;
+					}
+					else
+					{
+						(void) memset(spfctx->exp_buf, '\0', sizeof spfctx->exp_buf);
+						(void) strlcpy(spfctx->exp_buf, xp, sizeof spfctx->exp_buf);
+						spfctx->did_get_exp = TRUE;
+					}
 				}
-				(void) memset(spfctx->exp_buf, '\0', sizeof spfctx->exp_buf);
-				(void) strlcpy(spfctx->exp_buf, xp, sizeof spfctx->exp_buf);
-				spfctx->did_get_exp = TRUE;
-				continue;
 			}
-			if (strcasecmp("redirect", SPF_SP) == 0)
+			else if (strcasecmp("redirect", SPF_SP) == 0)
 			{
 				/*
 				 * Some people think that redirect and include are the same.
 				 * Rather than fail due to that belief, there is really no harm
 				 * in treating them the same.
 				 */
-				int	reply;
 				char *	xp;
 				char	query[MAXDNSHOSTNAME];
-				char *  spf_ret;
-				char	cname[128];
-				char	spfbuf[BUFSIZ];
 
 				if (vp == NULL)
 				{
 					(void) strlcat(xbuf, " Lacked a domain specification: FAILED", xbuf_len);
 					PUSHLINE
-					return spfctx->status = SPF_RETURN_REDIRECT_NO_DOMAIN;
+					stack[s].result = SPF_RETURN_REDIRECT_NO_DOMAIN;
 				}
-				(void) memset(query, '\0', sizeof query);
-				xp = opendmarc_spf_macro_expand(spfctx, vp, query, sizeof query, TRUE);
-				if (xp == NULL)
+				else
 				{
-					(void) strlcpy(xbuf, "\"redirect:\" record had syntactially bad macros:" , xbuf_len);
-					strlcat_multi(xbuf, xbuf_len, vp, ": FAILED");
-					PUSHLINE
-					return spfctx->status = SPF_RETURN_BAD_MACRO_SYNTAX;
-				}
-				++dns_count;
-				spf_ret = opendmarc_spf_dns_get_record(query, &reply, spfbuf, sizeof spfbuf, cname, sizeof cname, TRUE);
-				if (spf_ret == NULL)
-				{
-					strlcat_multi(xbuf, xbuf_len, vp, " lacked an SPF record: FAILED");
-					if (s == 0 && prefix == '-')
+					(void) memset(query, '\0', sizeof query);
+					xp = opendmarc_spf_macro_expand(spfctx, vp, query, sizeof query, TRUE);
+					if (xp == NULL)
 					{
-						return spfctx->status = SPF_RETURN_DASH_FORCED_HARD_FAIL;
+						(void) strlcpy(xbuf, "\"redirect:\" record had syntactially bad macros:" , xbuf_len);
+						strlcat_multi(xbuf, xbuf_len, vp, ": FAILED");
+						PUSHLINE
+						stack[s].result = SPF_RETURN_BAD_MACRO_SYNTAX;
 					}
-					PUSHLINE
-					return spfctx->status = SPF_RETURN_BAD_SYNTAX_REDIRECT;
+					else
+					{
+						++dns_count;
+						(void) strlcpy(stack[s].redirect, query, MAXDNSHOSTNAME);
+					}
 				}
-				(void) memset(stack[s].domain, '\0', MAXDNSHOSTNAME);
-				(void) strlcpy(stack[s].domain, vp, MAXDNSHOSTNAME);
-				(void) memset(stack[s].spf, '\0', SPF_MAX_SPF_RECORD_LEN);
-				(void) strlcpy(stack[s].spf, spfbuf, SPF_MAX_SPF_RECORD_LEN);
-				SPF_SP  = stack[s].spf;
-				SPF_EP  = stack[s].spf + strlen(stack[s].spf);
-				SPF_ESP = stack[s].spf - 1;
-				up = TRUE;
-				break;
 			}
-			if (strlen(SPF_SP) > 0)
+			else if (strlen(SPF_SP) > 0)
 			{
 				strlcat_multi(xbuf, xbuf_len, "\"", SPF_SP, "\": Unrecognized SPF keyword, WARNING");
 				PUSHLINE
 				/* return spfctx->status = SPF_RETURN_UNKNOWN_KEYWORD; */
-				continue;
 			}
 		}
 	}
@@ -1920,7 +1969,6 @@ opendmarc_spf_free_ctx(SPF_CTX_T *spfctx)
 	{
 		if (spfctx->lines[i] != NULL)
 		{
-			fprintf(stderr, "line[%d]: %s\n", i, spfctx->lines[i]);
 			(void) free(spfctx->lines[i]);
 		}
 	}
@@ -2149,8 +2197,8 @@ opendmarc_spf_test(char *ip_address, char *mail_from_domain, char *helo_domain, 
 		switch (ret)
 		{
 		    case SPF_RETURN_UNDECIDED:
-		    case SPF_RETURN_QMARK_ALL_NEUTRAL:
-		    case SPF_RETURN_TILDE_ALL_SOFT_FAIL:
+		    case SPF_RETURN_NEUTRAL:
+		    case SPF_RETURN_SOFTFAIL:
 			if (softfail_okay_flag == TRUE)
 				return DMARC_POLICY_SPF_OUTCOME_PASS;
 			else

--- a/libopendmarc/opendmarc_spf.c
+++ b/libopendmarc/opendmarc_spf.c
@@ -1466,7 +1466,7 @@ opendmarc_spf_parse(SPF_CTX_T *spfctx, int dns_count, char *xbuf, size_t xbuf_le
 				char **	app;
 				char 	abuf[BUFSIZ];
 
-				if (vp == NULL || split == SPLIT_SLASH)
+				if (strcasecmp(SPF_SP, "a") == 0 && (vp == NULL || split == SPLIT_SLASH))
 				{
 
 					/*


### PR DESCRIPTION
Hi everyone,

initiated by #169, I put together this PR, which substantially improves the integrated SPF part of opendmarc. It now correctly evaluates mechanisms with qualifiers other than '+'/none and follows include directives back down the stack if the result of an included result produces a NOMATCH according to [RFC 7208 Section 5](https://datatracker.ietf.org/doc/html/rfc7208#section-5.2) .

Also, redirects are handled according to the RFC and are only evaluated if there is no other matching mechanism (all!). I think it does not make any sense to try to guess what was meant by "redirect" as was previously done in the code (and handling it rather like an include).

I also changed the outcome of three testcases in that regard, which -- if I'm not mistaken -- clearly expected wrong results (and got those from the implementation).

I had to slightlly change the overall structure of the code, so this has become rather large.

Would be happy about some comments and even more happy to see it merged eventually. 

I also found a bunch of [older SPF test cases](http://www.open-spf.org/svn/project/test-suite/), which I think would be worth integrating into the opendmarc SPF tests. There will need to be some extensions for specifying a whole bunch of SPF records instead of just the entry record (which makes sense anyways). So next, I think I am going to work on integrating those and extending the opendmarc SPF implementation to be able to handle them.

Andreas