### PR TITLE
Suppress empty brackets in syslog startup message

### DIFF
--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -5255,8 +5255,11 @@ main(int argc, char **argv)
 			n -= status;
 		}
 
-		syslog(LOG_INFO, "%s v%s starting (%s)", DMARCF_PRODUCT,
-		       VERSION, argstr);
+		syslog(LOG_INFO, "%s v%s starting%s%s%s", DMARCF_PRODUCT,
+		       VERSION,
+		       strlen(argstr) == 0 ? "" : " (",
+		       argstr,
+		       strlen(argstr) == 0 ? "" : ")");
 
 		memset(argstr, '\0', sizeof argstr);
 		strlcpy(argstr, "(none)", sizeof argstr);


### PR DESCRIPTION
The proposed change suppresses a trailing empty pair of round brackets in the startup log message.

This is a small cosmetic improvement. The same change was merged in OpenDKIM (https://github.com/trusteddomainproject/OpenDKIM/pull/65), it would be good to merge it here as well.