### PR TITLE
Make sure a trailing brackets corresponds to a leading one

### DIFF
--- a/opendmarc/parse.c
+++ b/opendmarc/parse.c
@@ -454,6 +454,11 @@ dmarcf_mail_parse(unsigned char *line, unsigned char **user_out,
 					*domain_out = w;
 					ws = 0;
 				}
+				else if (type == '>')
+				{
+					err = MAILPARSE_ERR_SUNBALANCED;
+					return err;
+				}
 				else
 				{
 


### PR DESCRIPTION
This fixes the case where the sender e-mail address is user@example.net>
Without this fix, OpenDMARC parses the domain as example.net> and skip
DMARC processing since there is no policy for the domain.

Unfortunately, the MTA or MUA tend to fix the trailing bracket on their
own, letting forged e-mail passing through to user mailboxes.