### PR TITLE
Make function ‘check_domain’ static

### DIFF
--- a/libopendmarc/opendmarc_policy.c
+++ b/libopendmarc/opendmarc_policy.c
@@ -35,7 +35,7 @@
 **  	TRUE if the syntax was fine, FALSE otherwise.
 */
 
-bool check_domain(u_char *domain)
+static bool check_domain(u_char *domain)
 {
 	u_char *dp;
 


### PR DESCRIPTION
While packaging OpenDMARC 1.4.1.1 for Debian we discovered that the function `check_domain` in libopendmarc/opendmarc_policy.c was added to the public ABI:

https://salsa.debian.org/kitterman/opendmarc/-/blob/1ec111cf4785bcbd786d2f1bb443ec0c5810a0d0/debian/libopendmarc2.symbols#L3

This looks like a mistake. The function is not in any header files, doesn’t conform to naming conventions for libopendmarc, isn’t documented, and is used only locally in libopendmarc/opendmarc_policy.c.

The proposed change makes the function `static`.