### PR TITLE
Fix multi-value From rejection logic

### DIFF
--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -2479,12 +2479,12 @@ mlfi_eom(SMFICTX *ctx)
 				syslog(LOG_ERR,
 				       "%s: multi-valued From field detected",
 				       dfc->mctx_jobid);
-			}
 
-			if (conf->conf_reject_multi_from)
-				return SMFIS_REJECT;
-			else
-				return SMFIS_ACCEPT;
+				if (conf->conf_reject_multi_from)
+					return SMFIS_REJECT;
+				else
+					return SMFIS_ACCEPT;
+			}
 		}
 
 		user = users[0];

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -2476,9 +2476,12 @@ mlfi_eom(SMFICTX *ctx)
 		{
 			if (strcasecmp(domains[0], domains[c]) != 0)
 			{
-				syslog(LOG_ERR,
-				       "%s: multi-valued From field detected",
-				       dfc->mctx_jobid);
+				if (conf->conf_dolog)
+				{
+					syslog(LOG_ERR,
+					       "%s: multi-valued From field detected",
+					       dfc->mctx_jobid);
+				}
 
 				if (conf->conf_reject_multi_from)
 					return SMFIS_REJECT;


### PR DESCRIPTION
This change fixes the broken reject logic when a multi-value `From` header field is detected.

It includes an unrelated addition, namely the missing if-guard before the syslog call, as is done elsewhere in this function.

This fixes #175.
