### PR TITLE
Closed the gate for buffer overrun

### DIFF
--- a/libopendmarc/opendmarc_util.c
+++ b/libopendmarc/opendmarc_util.c
@@ -160,7 +160,7 @@ opendmarc_util_cleanup(u_char *str, u_char *buf, size_t buflen)
 {
 	char *sp, *ep;
 
-	if (str == NULL || buf == NULL || strlen((char *)str) > buflen)
+	if (str == NULL || buf == NULL || strlen((char *)str) >= buflen)
 	{
 		errno = EINVAL;
 		return NULL;


### PR DESCRIPTION
In case if a string length matches the length of a buffer, the function will return a non-null-terminated string.