### PR TITLE
debian patch 193 - database schema corrections

### DIFF
--- a/db/Makefile.am
+++ b/db/Makefile.am
@@ -1,3 +1,3 @@
 # Copyright (c) 2012, The Trusted Domain Project.  All rights reserved.
 
-dist_doc_DATA = README.schema schema.mysql
+dist_doc_DATA = README.schema schema.mysql README.update-db-schema.mysql update-db-schema.mysql

--- a/db/README.update-db-schema.mysql
+++ b/db/README.update-db-schema.mysql
@@ -1,0 +1,8 @@
+
+To update your database to the current state use this script like this:
+
+  mysql -u <user> -p <passwd> --force < update-db-schema.mysql
+
+You might receive up to four errors about duplicate keys - this is expected if your database
+already has these keys (because you used the MySQL schema in the db sub-direcory instead of
+the obsolete schema in the reports sub-dirctory).

--- a/db/schema.mysql
+++ b/db/schema.mysql
@@ -5,6 +5,7 @@
 
 CREATE DATABASE IF NOT EXISTS opendmarc;
 USE opendmarc;
+SET TIME_ZONE='+00:00';
 
 -- A table for mapping domain names and their DMARC policies to IDs
 CREATE TABLE IF NOT EXISTS domains (
@@ -66,7 +67,7 @@ CREATE TABLE IF NOT EXISTS requests (
 	pct TINYINT NOT NULL DEFAULT '0',
 	locked TINYINT NOT NULL DEFAULT '0',
 	firstseen TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-	lastsent TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:00',
+	lastsent TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:01',
 
 	PRIMARY KEY(id),
 	KEY(lastsent),

--- a/db/update-db-schema.mysql
+++ b/db/update-db-schema.mysql
@@ -1,0 +1,12 @@
+use opendmarc;
+SET TIME_ZONE="+00:00";
+ALTER TABLE ipaddr MODIFY COLUMN addr VARCHAR(64) NOT NULL;
+DELETE FROM ipaddr WHERE addr = NULL;
+ALTER TABLE messages MODIFY COLUMN spf TINYINT NOT NULL;
+ALTER TABLE requests ALTER COLUMN locked SET DEFAULT '0';
+ALTER TABLE requests ALTER COLUMN lastsent SET DEFAULT '1970-01-01 00:00:01';
+ALTER TABLE requests ADD UNIQUE KEY domain (domain);
+ALTER TABLE requests ADD KEY lastsent (lastsent);
+ALTER TABLE messages ADD KEY date (date);
+ALTER TABLE signatures ADD KEY message (message);
+

--- a/reports/opendmarc-import.in
+++ b/reports/opendmarc-import.in
@@ -233,14 +233,12 @@ sub update_db
 	$envfrom_id = get_table_id($envdomain, "domains");
 	$pdomain_id = get_table_id($pdomain, "domains");
 	$ipaddr_id = get_table_id($ipaddr, "ipaddr", "addr");
-	$request_id = get_table_id($from_id, "requests", "domain");
 
 	if (!defined($rep_id) ||
 	    !defined($from_id) ||
 	    !defined($envfrom_id) ||
 	    !defined($pdomain_id) ||
-	    !defined($ipaddr_id) ||
-	    !defined($request_id))
+	    !defined($ipaddr_id))
 	{
 		return;
 	}
@@ -372,39 +370,48 @@ sub update_db
 
 	if (get_value("requests", "locked", $request_id) != 1)
 	{
-		if (scalar @rua > 0)
+		print STDERR "$progname: failed to retrieve table ID: " . $dbi_h->errstr . "\n";
+		return undef;
+	}
+
+	undef $request_id;
+	while ($dbi_a = $dbi_t->fetchrow_arrayref())
+	{
+		if (defined($dbi_a->[0]))
 		{
-			$repuri = join(",", @rua);
-			$dbi_s = $dbi_h->prepare("UPDATE requests SET repuri = ? WHERE id = ?");
-
-			if (!$dbi_s->execute($repuri, $request_id))
-			{
-				print STDERR "$progname: failed to update reporting URI for $fdomain: " . $dbi_h->errstr . "\n";
-				$dbi_s->finish;
-				return;
-			}
-
-			$dbi_s->finish;
+			$request_id = $dbi_a->[0];
 		}
-		else
+	}
+
+	$dbi_t->finish;
+
+	$repuri = join(",", @rua);
+
+	if (defined($request_id))
+	{
+		if (get_value("requests", "locked", $request_id) != 1)
 		{
 			$dbi_s = $dbi_h->prepare("UPDATE requests SET repuri = '' WHERE id = ?");
 
-			if (!$dbi_s->execute($request_id))
+			if (!$dbi_s->execute($from_id, $repuri, $adkim, $aspf, $p, $sp, $pct, $request_id))
 			{
-				print STDERR "$progname: failed to update reporting URI for $fdomain: " . $dbi_h->errstr . "\n";
+				print STDERR "$progname: failed to update policy data for $fdomain: " . $dbi_h->errstr . "\n";
 				$dbi_s->finish;
 				return;
 			}
-
-			$dbi_s->finish;
 		}
-
-		$dbi_s = $dbi_h->prepare("UPDATE requests SET adkim = ?, aspf = ?, policy = ?, spolicy = ?, pct = ? WHERE id = ?");
-
-		if (!$dbi_s->execute($adkim, $aspf, $p, $sp, $pct, $request_id))
+		else
 		{
-			print STDERR "$progname: failed to update policy data for $fdomain: " . $dbi_h->errstr . "\n";
+			print STDERR "$progname: policy data for $fdomain not updated, because they are locked\n";
+		}
+	}
+	else
+	{
+		$dbi_s = $dbi_h->prepare("insert requests SET domain = ?, repuri = ?, adkim = ?, aspf = ?, policy = ?, spolicy = ?, pct = ?");
+
+		if (!$dbi_s->execute($from_id, $repuri, $adkim, $aspf, $p, $sp, $pct))
+		{
+			print STDERR "$progname: failed to insert policy data for $fdomain: " . $dbi_h->errstr . "\n";
 			$dbi_s->finish;
 			return;
 		}

--- a/reports/opendmarc-import.in
+++ b/reports/opendmarc-import.in
@@ -233,12 +233,14 @@ sub update_db
 	$envfrom_id = get_table_id($envdomain, "domains");
 	$pdomain_id = get_table_id($pdomain, "domains");
 	$ipaddr_id = get_table_id($ipaddr, "ipaddr", "addr");
+	$request_id = get_table_id($from_id, "requests", "domain");
 
 	if (!defined($rep_id) ||
 	    !defined($from_id) ||
 	    !defined($envfrom_id) ||
 	    !defined($pdomain_id) ||
-	    !defined($ipaddr_id))
+	    !defined($ipaddr_id) ||
+	    !defined($request_id))
 	{
 		return;
 	}
@@ -370,48 +372,39 @@ sub update_db
 
 	if (get_value("requests", "locked", $request_id) != 1)
 	{
-		print STDERR "$progname: failed to retrieve table ID: " . $dbi_h->errstr . "\n";
-		return undef;
-	}
-
-	undef $request_id;
-	while ($dbi_a = $dbi_t->fetchrow_arrayref())
-	{
-		if (defined($dbi_a->[0]))
+		if (scalar @rua > 0)
 		{
-			$request_id = $dbi_a->[0];
-		}
-	}
+			$repuri = join(",", @rua);
+			$dbi_s = $dbi_h->prepare("UPDATE requests SET repuri = ? WHERE id = ?");
 
-	$dbi_t->finish;
-
-	$repuri = join(",", @rua);
-
-	if (defined($request_id))
-	{
-		if (get_value("requests", "locked", $request_id) != 1)
-		{
-			$dbi_s = $dbi_h->prepare("UPDATE requests SET repuri = '' WHERE id = ?");
-
-			if (!$dbi_s->execute($from_id, $repuri, $adkim, $aspf, $p, $sp, $pct, $request_id))
+			if (!$dbi_s->execute($repuri, $request_id))
 			{
-				print STDERR "$progname: failed to update policy data for $fdomain: " . $dbi_h->errstr . "\n";
+				print STDERR "$progname: failed to update reporting URI for $fdomain: " . $dbi_h->errstr . "\n";
 				$dbi_s->finish;
 				return;
 			}
+
+			$dbi_s->finish;
 		}
 		else
 		{
-			print STDERR "$progname: policy data for $fdomain not updated, because they are locked\n";
-		}
-	}
-	else
-	{
-		$dbi_s = $dbi_h->prepare("insert requests SET domain = ?, repuri = ?, adkim = ?, aspf = ?, policy = ?, spolicy = ?, pct = ?");
+			$dbi_s = $dbi_h->prepare("UPDATE requests SET repuri = '' WHERE id = ?");
 
-		if (!$dbi_s->execute($from_id, $repuri, $adkim, $aspf, $p, $sp, $pct))
+			if (!$dbi_s->execute($request_id))
+			{
+				print STDERR "$progname: failed to update reporting URI for $fdomain: " . $dbi_h->errstr . "\n";
+				$dbi_s->finish;
+				return;
+			}
+
+			$dbi_s->finish;
+		}
+
+		$dbi_s = $dbi_h->prepare("UPDATE requests SET adkim = ?, aspf = ?, policy = ?, spolicy = ?, pct = ? WHERE id = ?");
+
+		if (!$dbi_s->execute($adkim, $aspf, $p, $sp, $pct, $request_id))
 		{
-			print STDERR "$progname: failed to insert policy data for $fdomain: " . $dbi_h->errstr . "\n";
+			print STDERR "$progname: failed to update policy data for $fdomain: " . $dbi_h->errstr . "\n";
 			$dbi_s->finish;
 			return;
 		}


### PR DESCRIPTION
The the release of v1.4.1 to Debian [patch 193](https://sources.debian.org/patches/opendmarc/1.4.1.1-1/ticket193.patch/) was applied. This had impact on:
- The database schema
- opendmarc-import (perl script)
- opendmarc-expire (perl script)
This PR applies Debian patch 193 to this repository but does omits changes made to opendmarc-import.

This PR solves issue #184 to the source by using the patch.
It sets a UTC time zone for `opendmarc-expire` as suggested from [debian patch 193](https://sources.debian.org/patches/opendmarc/1.4.1.1-1/ticket193.patch/).
