### PR TITLE
Remove doubled HoldQuarantinedMessages option

### DIFF
--- a/opendmarc/opendmarc.conf.sample
+++ b/opendmarc/opendmarc.conf.sample
@@ -234,20 +234,6 @@
 #
 # IgnoreAuthenticatedClients false
 
-## HoldQuarantinedMessages { true | false }
-##  	default "false"
-##
-##  If set, the milter will signal to the mta that messages with
-##  p=quarantine, which fail dmarc authentication, should be held in
-##  the MTA's "Hold" or "Quarantine" queue.  The name varies by MTA.
-##  If false, messsages will be accepted and passed along with the 
-##  regular mail flow, and the quarantine will be left up to downstream
-##  MTA/MDA/MUA filters, if any, to handle by re-evaluating the headers,
-##  including the Authentication-Results header added by OpenDMARC
-#
-# HoldQuarantinedMessages false
-
-
 ##  IgnoreHosts path
 ##  	default (internal)
 ##


### PR DESCRIPTION
HoldQuarantinedMessages option is used twice in the configuration sample. Remove the second one as it is not needed