### PR TITLE
Fix underlinking on glibc-2.33 and below

### DIFF
--- a/libopendmarc/Makefile.am
+++ b/libopendmarc/Makefile.am
@@ -15,5 +15,6 @@ libopendmarc_la_SOURCES	= dmarc.h \
 			  opendmarc_spf_dns.c \
                           opendmarc_internal.h
 libopendmarc_la_LDFLAGS = -version-info $(LIBOPENDMARC_VERSION_INFO)
+libopendmarc_la_LIBADD = $(LIBRESOLV)
 libopendmarc_includedir = $(includedir)/opendmarc
 libopendmarc_include_HEADERS = dmarc.h


### PR DESCRIPTION
* libopendmarc.so.2.0.3 uses
  - __dn_expand
  - __dn_skipname
  - __res_nquery
  which are defined in libresolv in glibc 2.33 and older.

See: https://bugs.gentoo.org/839951

To reproduce the problem: run `LDFLAGS="-Wl,--no-undefined" ./configure` against glibc 2.33 or below and you'll run into

```
/bin/sh ../libtool  --tag=CC   --mode=link gcc  -g -O2 -version-info 2:3:0 -no-undefined -Wl,--no-undefined -o libopendmarc.la -rpath /usr/local/lib opendmarc_dns.lo opendmarc_xml.lo opendmarc_tld.lo opendmarc_policy.lo opendmarc_util.lo opendmarc_hash.lo opendmarc_strl.lo opendmarc_spf.lo opendmarc_spf_dns.lo  -lm -lrt 
libtool: link: gcc -shared  -fPIC -DPIC  .libs/opendmarc_dns.o .libs/opendmarc_xml.o .libs/opendmarc_tld.o .libs/opendmarc_policy.o .libs/opendmarc_util.o .libs/opendmarc_hash.o .libs/opendmarc_strl.o .libs/opendmarc_spf.o .libs/opendmarc_spf_dns.o   -lm -lrt  -g -O2 -Wl,--no-undefined   -Wl,-soname -Wl,libopendmarc.so.2 -o .libs/libopendmarc.so.2.0.3
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/../../../../x86_64-pc-linux-gnu/bin/ld: .libs/opendmarc_dns.o: in function `dmarc_dns_get_record':
/root/OpenDMARC/libopendmarc/opendmarc_dns.c:212: undefined reference to `__res_nquery'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/../../../../x86_64-pc-linux-gnu/bin/ld: /root/OpenDMARC/libopendmarc/opendmarc_dns.c:248: undefined reference to `__dn_expand'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/../../../../x86_64-pc-linux-gnu/bin/ld: /root/OpenDMARC/libopendmarc/opendmarc_dns.c:250: undefined reference to `__dn_skipname'
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.1/../../../../x86_64-pc-linux-gnu/bin/ld: /root/OpenDMARC/libopendmarc/opendmarc_dns.c:277: undefined reference to `__dn_expand'
collect2: error: ld returned 1 exit status
```