### PR TITLE
Log warnings for ARC-Seal header parse failures

### DIFF
--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -2621,7 +2621,12 @@ mlfi_eom(SMFICTX *ctx)
 
 		/* parse it */
 		if (opendmarc_arcseal_parse(hdr->hdr_value, &as_hdr_new->arcseal) != 0)
+		{
+			syslog(LOG_WARNING,
+			       "%s: ignoring invalid %s header \"%s\"",
+			       dfc->mctx_jobid, hdr->hdr_name, hdr->hdr_value);
 			continue;
+		}
 
 		if (dfc->mctx_ashead == NULL)
 		{


### PR DESCRIPTION
To identify cases where header parsing can be improved, which may be useful in cases like https://github.com/trusteddomainproject/OpenDMARC/issues/222 and https://github.com/trusteddomainproject/OpenDMARC/issues/183.