### PR TITLE
Increase OPENDMARC_ARCSEAL_MAX_TOKEN_LEN to 768

### DIFF
--- a/opendmarc/opendmarc-arcseal.c
+++ b/opendmarc/opendmarc-arcseal.c
@@ -29,7 +29,7 @@
 #include "opendmarc.h"
 
 #define OPENDMARC_ARCSEAL_MAX_FIELD_NAME_LEN 255
-#define OPENDMARC_ARCSEAL_MAX_TOKEN_LEN      512
+#define OPENDMARC_ARCSEAL_MAX_TOKEN_LEN      768
 
 /* tables */
 struct opendmarc_arcseal_lookup


### PR DESCRIPTION
Enough for 3072 bit key signatures. Should fix https://github.com/trusteddomainproject/OpenDMARC/issues/183.