### PR TITLE
Hold quarantined messages

### DIFF
--- a/opendmarc/opendmarc.conf.sample
+++ b/opendmarc/opendmarc.conf.sample
@@ -234,20 +234,6 @@
 #
 # IgnoreAuthenticatedClients false
 
-## HoldQuarantinedMessages { true | false }
-##  	default "false"
-##
-##  If set, the milter will signal to the mta that messages with
-##  p=quarantine, which fail dmarc authentication, should be held in
-##  the MTA's "Hold" or "Quarantine" queue.  The name varies by MTA.
-##  If false, messsages will be accepted and passed along with the 
-##  regular mail flow, and the quarantine will be left up to downstream
-##  MTA/MDA/MUA filters, if any, to handle by re-evaluating the headers,
-##  including the Authentication-Results header added by OpenDMARC
-#
-# HoldQuarantinedMessages false
-
-
 ##  IgnoreHosts path
 ##  	default (internal)
 ##

--- a/opendmarc/opendmarc.conf.sample
+++ b/opendmarc/opendmarc.conf.sample
@@ -222,7 +222,7 @@
 ##  If false, messsages will be accepted and passed along with the 
 ##  regular mail flow, and the quarantine will be left up to downstream
 ##  MTA/MDA/MUA filters, if any, to handle by re-evaluating the headers,
-##  including the Authentication-Results header added by OpenDMARC
+##  including the Authentication-Results header added by OpenDMARC.
 #
 # HoldQuarantinedMessages false
 
@@ -277,7 +277,7 @@
 ##  as described in the DMARC specification.  If not provided, the filter will
 ##  not be able to determine the Organizational Domain and only the presented
 ##  domain will be evaluated.  This file should be periodically updated.
-##  One location to retrieve the file from is https://publicsuffix.org/list/
+##  One location to retrieve the file from is https://publicsuffix.org/list/.
 #
 # PublicSuffixList path
 


### PR DESCRIPTION
The sample configuration file contained a duplicate section for "HoldQuarantinedMessages".  This PR removes the duplicate section and adds a trailing period at the ends of two sentences in the comments.