### PR TITLE
Remove non-existent syslog.target from service file

### DIFF
--- a/contrib/service/opendmarc.service.in
+++ b/contrib/service/opendmarc.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=Domain-based Message Authentication, Reporting & Conformance (DMARC) Milter
 Documentation=man:opendmarc(8) man:opendmarc.conf(5) man:opendmarc-import(8) man:opendmarc-reports(8) http://www.trusteddomain.org/opendmarc/
-After=network.target nss-lookup.target syslog.target
+After=network.target nss-lookup.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
syslog.target was removed more than a decade ago - https://github.com/systemd/systemd/blob/6aa8d43ade72e24c9426e604f7fc4b7582b9db7c/NEWS#L72-L73