### PR TITLE
opendmarc-ar: Accept AR header with a no-result as valid syntax.

### DIFF
--- a/opendmarc/opendmarc-ar.c
+++ b/opendmarc/opendmarc-ar.c
@@ -422,7 +422,7 @@ ares_parse(u_char *hdr, struct authres *ar)
 			if (tokens[c][0] == ';')
 			{
 				prevstate = state;
-				state = 3;
+				state = 14;
 			}
 			else if (isascii(tokens[c][0]) &&
 			         isdigit(tokens[c][0]))
@@ -447,9 +447,19 @@ ares_parse(u_char *hdr, struct authres *ar)
 				return -1;
 
 			prevstate = state;
-			state = 3;
+			state = 14;
 
 			break;
+
+		  case 14:				/* method or "none" */
+			if (strcasecmp((char *) tokens[c], "none") == 0)
+			{
+				prevstate = state;
+				state = 15;
+				continue;
+			}
+
+			/* FALLTHROUGH */
 
 		  case 3:				/* method */
 			n++;
@@ -619,6 +629,10 @@ ares_parse(u_char *hdr, struct authres *ar)
 			}
 
 			break;
+
+		  case 15:				/* terminal state after no-result */
+			/* any token should not appear */
+			return -1;
 		}
 	}
 


### PR DESCRIPTION
Current parser for Authentication header does not accept the case that authres-payload contains no-result in [RFC8601 section 2.2](https://datatracker.ietf.org/doc/html/rfc8601#section-2.2).

This is a fix for it.

This PR is similer to [PR #205 on OpenDKIM](https://github.com/trusteddomainproject/OpenDKIM/pull/205).