### PR TITLE
Fix incorrect alignment check behavior in DMARC strict mode

### DIFF
--- a/libopendmarc/opendmarc_policy.c
+++ b/libopendmarc/opendmarc_policy.c
@@ -307,6 +307,16 @@ opendmarc_policy_check_alignment(u_char *subdomain, u_char *tld, int mode)
 	if (strcasecmp(rev_tld, rev_sub) == 0)
 		return 0;
 
+	/*
+	 * For strict mode, only exact matches are allowed
+	 * as per RFC 7489 Section 3.1.1 and 3.1.2
+	 */
+	if (mode == DMARC_RECORD_A_STRICT)
+		return -1;
+
+	/*
+	 * For relaxed mode, check if domain or subdomain matches
+	 */
 	ret = strncasecmp(rev_tld, rev_sub, strlen(rev_tld));
 	if (ret == 0 && mode == DMARC_RECORD_A_RELAXED)
 			return 0;
@@ -324,12 +334,7 @@ opendmarc_policy_check_alignment(u_char *subdomain, u_char *tld, int mode)
 	if (*ep != '.')
 		(void) strlcat((char *)rev_tld, ".", sizeof rev_tld);
 
-	/*
-	 * Perfect match is aligned irrespective of relaxed or strict.
-	 */
-	if (strcasecmp(rev_tld, rev_sub) == 0)
-		return 0;
-
+	/* Check organizational domain match for relaxed mode */
 	ret = strncasecmp(rev_tld, rev_sub, strlen(rev_tld));
 	if (ret == 0 && mode == DMARC_RECORD_A_RELAXED)
 			return 0;


### PR DESCRIPTION
The current implementation incorrectly allows partial domain matches in strict
alignment mode. According to RFC 7489 Section 3.1.1 and 3.1.2, strict alignment
(adkim=s or aspf=s) requires an exact match between the RFC5322.From domain
and the domain being evaluated.

The issue occurs when Public Suffix List is configured. Current behavior with
strict mode shows an incorrect match:
From: user@sub.example.com, envelope from: sender@example.com
1. First exact match fails (correct: sub.example.com ≠ example.com)
2. Gets TLD+1 from header From domain (example.com from sub.example.com)
3. Matches this TLD+1 against envelope from (example.com)
4. Results in PASS (incorrect in strict mode)

Note: When Public Suffix List is not configured, this incorrect matching
does not occur because TLD resolution returns the entire domain unchanged.

The reverse case works correctly regardless of Public Suffix List configuration:
From: user@example.com, envelope from: sender@sub.example.com
1. First exact match fails
2. Further checks fail
3. Results in FAIL (correct for strict mode)

The problem affects both SPF (aspf=s) and DKIM (adkim=s) alignment checks
equally, as they use the same alignment checking function.

This patch:
1. Makes strict mode return immediately after the initial exact match check fails
2. Removes TLD resolution based matching for strict mode
3. Preserves existing relaxed mode behavior

The changes ensure proper implementation of RFC 7489's requirement that strict
mode must only allow exact matches between domains.