### PR TITLE
Improve MariaDB support in report Perl scripts

### DIFF
--- a/reports/opendmarc-expire.8.in
+++ b/reports/opendmarc-expire.8.in
@@ -14,6 +14,9 @@ reporting feature.
 .I --alltables
 Expire records in all tables rather than only the large ones.
 .TP
+.I --dbscheme=scheme
+Specify "msyql" (the default) or "MariaDB".
+.TP
 .I --dbhost=host
 Attempts to connect to the database server on the named
 .I host.

--- a/reports/opendmarc-expire.in
+++ b/reports/opendmarc-expire.in
@@ -18,8 +18,6 @@ use Getopt::Long;
 use IO::Handle;
 use POSIX;
 
-require DBD::@SQL_BACKEND@;
-
 # general
 my $progname      = basename($0);
 my $version       = "@VERSION@";
@@ -36,6 +34,7 @@ my $dbi_h;
 my $dbi_a;
 
 # DB parameters
+my $def_dbscheme  = "@SQL_BACKEND@";
 my $def_dbhost    = "localhost";
 my $def_dbname    = "opendmarc";
 my $def_dbuser    = "opendmarc";
@@ -47,7 +46,7 @@ my $dbuser;
 my $dbpasswd;
 my $dbport;
 
-my $dbscheme      = "@SQL_BACKEND@";
+my $dbscheme      = $def_dbscheme;
 
 my $def_maxage    = 180;
 
@@ -62,6 +61,7 @@ sub usage
 {
 	print STDERR "$progname: usage: $progname [options]\n";
 	print STDERR "\t--alltables        expire rows from all tables\n";
+	print STDERR "\t--dbscheme=scheme  mysql or MariaDB [$def_dbscheme]\n";
 	print STDERR "\t--dbhost=host      database host [$def_dbhost]\n";
 	print STDERR "\t--dbname=name      database name [$def_dbname]\n";
 	print STDERR "\t--dbpasswd=passwd  database password [$def_dbpasswd]\n";
@@ -75,6 +75,7 @@ sub usage
 
 # parse command line arguments
 my $opt_retval = &Getopt::Long::GetOptions ('alltables!' => \$alltables,
+                                            'dbscheme=s' => \$dbscheme,
                                             'dbhost=s' => \$dbhost,
                                             'dbname=s' => \$dbname,
                                             'dbpasswd=s' => \$dbpasswd,
@@ -195,8 +196,13 @@ if ($verbose)
 	print STDERR "$progname: started at " . localtime() . "\n";
 }
 
+require "DBD/$dbscheme.pm";
+
 my $dbi_dsn = "DBI:" . $dbscheme . ":database=" . $dbname .
-              ";host=" . $dbhost . ";port=" . $dbport;
+              ";host=" . $dbhost;
+if ($dbport != $def_dbport) {
+    $dbi_dsn .= ";port=" . $dbport;
+}
 
 $dbi_h = DBI->connect($dbi_dsn, $dbuser, $dbpasswd, { PrintError => 0 });
 if (!defined($dbi_h))

--- a/reports/opendmarc-import.8.in
+++ b/reports/opendmarc-import.8.in
@@ -14,6 +14,9 @@ and inserts it into an SQL database, for later use by
 to generate aggregate reports.
 .SH OPTIONS
 .TP
+.I --dbscheme=scheme
+Specify "msyql" (the default) or "MariaDB".
+.TP
 .I --dbhost=hostname
 Specifies the hostname on which the SQL server is running.  Defaults to
 the value of the environment variable OPENDMARC_DBHOST, or "localhost" if

--- a/reports/opendmarc-import.in
+++ b/reports/opendmarc-import.in
@@ -291,7 +291,7 @@ sub update_db
 	}
 
 	$dbi_s = $dbi_h->prepare("INSERT INTO signatures (message, domain, selector, pass, error) VALUES(?, ?, ?, ?, ?)");
-	foreach my $dd (0 .. $#dkim_data)
+	foreach my $dd (0 .. @dkim_data-1)
 	{
 		my $sdomain;
 		my $sdomain_id;
@@ -323,7 +323,7 @@ sub update_db
 	$dbi_s->finish;
 
 	$dbi_s = $dbi_h->prepare("INSERT INTO arcauthresults (message, instance, arc_client_addr) VALUES(?, ?, ?)");
-	foreach my $aar (0 .. $#arc_policy_data)
+	foreach my $aar (0 .. @arc_policy_data-1)
 	{
 		my $instance;
 		my $arc_client_addr;
@@ -341,7 +341,7 @@ sub update_db
 	$dbi_s->finish;
 
 	$dbi_s = $dbi_h->prepare("INSERT INTO arcseals (message, domain, selector, instance) VALUES(?, ?, ?, ?)");
-	foreach my $as (0 .. $#arc_policy_data)
+	foreach my $as (0 .. @arc_policy_data-1)
 	{
 		my $sdomain;
 		my $sdomain_id;

--- a/reports/opendmarc-import.in
+++ b/reports/opendmarc-import.in
@@ -20,8 +20,6 @@ use Getopt::Long;
 use POSIX;
 use JSON;
 
-require DBD::@SQL_BACKEND@;
-
 # general
 my $progname      = basename($0);
 my $version       = "@VERSION@";
@@ -30,6 +28,7 @@ my $helponly      = 0;
 my $showversion   = 0;
 
 # DB parameters
+my $def_dbscheme  = "@SQL_BACKEND@";
 my $def_dbhost    = "localhost";
 my $def_dbname    = "opendmarc";
 my $def_dbuser    = "opendmarc";
@@ -45,7 +44,7 @@ my $dbport;
 my $inputfile;
 my $inputfh;
 
-my $dbscheme     = "@SQL_BACKEND@";
+my $dbscheme     = $def_dbscheme;
 
 my $dbi_a;
 my $dbi_h;
@@ -416,6 +415,7 @@ sub update_db
 sub usage
 {
 	print STDERR "$progname: usage: $progname [options]\n";
+	print STDERR "\t--dbscheme=scheme  mysql or MariaDB [$def_dbscheme]\n";
 	print STDERR "\t--dbhost=host      database host [$def_dbhost]\n";
 	print STDERR "\t--dbname=name      database name [$def_dbname]\n";
 	print STDERR "\t--dbpasswd=passwd  database password [$def_dbpasswd]\n";
@@ -428,7 +428,8 @@ sub usage
 }
 
 # parse command line arguments
-my $opt_retval = &Getopt::Long::GetOptions ('dbhost=s' => \$dbhost,
+my $opt_retval = &Getopt::Long::GetOptions ('dbscheme=s' => \$dbscheme,
+                                            'dbhost=s' => \$dbhost,
                                             'dbname=s' => \$dbname,
                                             'dbpasswd=s' => \$dbpasswd,
                                             'dbport=s' => \$dbport,
@@ -543,8 +544,13 @@ if (!flock($inputfh, LOCK_SH))
 	print STDERR "$progname: warning: unable to establish read lock\n";
 }
 
+require "DBD/$dbscheme.pm";
+
 my $dbi_dsn = "DBI:" . $dbscheme . ":database=" . $dbname .
-              ";host=" . $dbhost . ";port=" . $dbport;
+    ";host=" . $dbhost;
+if ($dbport != $def_dbport) {
+    $dbi_dsn .= ";port=" . $dbport;
+}
 
 $dbi_h = DBI->connect($dbi_dsn, $dbuser, $dbpasswd, { PrintError => 0 });
 if (!defined($dbi_h))

--- a/reports/opendmarc-reports.8.in
+++ b/reports/opendmarc-reports.8.in
@@ -22,6 +22,9 @@ Generate reports on day boundaries.  Overrides the value of
 .I --interval
 (see below).
 .TP
+.I --dbscheme=scheme
+Specify "msyql" (the default) or "MariaDB".
+.TP
 .I --dbhost=hostname
 Specifies the hostname on which the SQL server is running.  Defaults to
 the value of the environment variable OPENDMARC_DBHOST, or "localhost" if

--- a/reports/opendmarc-reports.in
+++ b/reports/opendmarc-reports.in
@@ -14,7 +14,7 @@ use warnings;
 
 use Switch;
 
-use DBI;
+use DBI qw(:sql_types);
 use File::Basename;
 use File::Temp;
 use Net::Domain qw(hostfqdn hostdomain);
@@ -448,7 +448,8 @@ foreach (@$domainset)
 	}
 
 	$dbi_s = $dbi_h->prepare("SELECT repuri, adkim, aspf, policy, spolicy, pct, UNIX_TIMESTAMP(lastsent) FROM requests WHERE domain = ?");
-	if (!$dbi_s->execute($domainid))
+        $dbi_s->bind_param(1, $domainid, {TYPE => SQL_INTEGER});
+	if (!$dbi_s->execute())
 	{
 		print STDERR "$progname: can't get reporting URI for domain $domain: " . $dbi_h->errstr . "\n";
 		$dbi_s->finish;
@@ -609,7 +610,10 @@ foreach (@$domainset)
 		});
 	}
 
-	if (!$dbi_s->execute($domainid, $repstart, $repend))
+        $dbi_s->bind_param(1, $domainid, {TYPE => SQL_INTEGER});
+        $dbi_s->bind_param(2, $repstart, {TYPE => SQL_INTEGER});
+        $dbi_s->bind_param(3, $repend, {TYPE => SQL_INTEGER});
+	if (!$dbi_s->execute())
 	{
 		print STDERR "$progname: can't extract report for domain $domain: " . $dbi_h->errstr . "\n";
 		$dbi_s->finish;
@@ -735,7 +739,8 @@ foreach (@$domainset)
 		                          WHERE arcseals.message = ?
 		                          ORDER BY arcseals.instance DESC
 		});
-		if (!$dbi_s2->execute($msgid))
+                $dbi_s2->bind_param(1, $msgid, {TYPE => SQL_INTEGER});
+		if (!$dbi_s2->execute())
 		{
 			print STDERR "$progname: can't extract report for message $msgid: " . $dbi_h->errstr . "\n";
 			$dbi_s2->finish;
@@ -787,7 +792,8 @@ foreach (@$domainset)
 		                          JOIN selectors ON signatures.selector = selectors.id
 		                          WHERE signatures.message = ?
 		});
-		if (!$dbi_s2->execute($msgid))
+                $dbi_s2->bind_param(1, $msgid, {TYPE => SQL_INTEGER});
+		if (!$dbi_s2->execute())
 		{
 			print STDERR "$progname: can't extract report for message $msgid: " . $dbi_h->errstr . "\n";
 			$dbi_s2->finish;
@@ -1035,7 +1041,9 @@ foreach (@$domainset)
 	if ($doupdate)
 	{
 		$dbi_s = $dbi_h->prepare("UPDATE requests SET lastsent = FROM_UNIXTIME(?) WHERE domain = ?");
-		if (!$dbi_s->execute($repend, $domainid))
+                $dbi_s->bind_param(1, $repend, {TYPE => SQL_INTEGER});
+                $dbi_s->bind_param(2, $domainid, {TYPE => SQL_INTEGER});
+		if (!$dbi_s->execute())
 		{
 			print STDERR "$progname: can't update last sent time for domain $domain: " . $dbi_h->errstr . "\n";
 			$dbi_s->finish;

--- a/reports/opendmarc-reports.in
+++ b/reports/opendmarc-reports.in
@@ -26,8 +26,6 @@ use MIME::Base64;
 use Net::SMTP;
 use Time::Local;
 
-require DBD::@SQL_BACKEND@;
-
 require HTTP::Request;
 
 # general
@@ -122,6 +120,7 @@ my $dbi_a;
 my $dbi_hash;
 
 # DB parameters
+my $def_dbscheme  = $def_dbscheme;
 my $def_dbhost    = "localhost";
 my $def_dbname    = "opendmarc";
 my $def_dbuser    = "opendmarc";
@@ -134,7 +133,7 @@ my $dbuser;
 my $dbpasswd;
 my $dbport;
 
-my $dbscheme     = "@SQL_BACKEND@";
+my $dbscheme     = $def_dbscheme;
 
 my $repdom       = hostdomain();
 my $repemail     = "postmaster@" . $repdom;
@@ -153,6 +152,7 @@ sub usage
 {
 	print STDERR "$progname: usage: $progname [options]\n";
 	print STDERR "\t--day              send yesterday's data\n";
+	print STDERR "\t--dbscheme=scheme  mysql or MariaDB [$def_dbscheme]\n";
 	print STDERR "\t--dbhost=host      database host [$def_dbhost]\n";
 	print STDERR "\t--dbname=name      database name [$def_dbname]\n";
 	print STDERR "\t--dbpasswd=passwd  database password [$def_dbpasswd]\n";
@@ -182,6 +182,7 @@ setlocale(LC_ALL, 'C');
 
 # parse command line arguments
 my $opt_retval = &Getopt::Long::GetOptions ('day!' => \$daybound,
+                                            'dbscheme=s' => \$dbscheme,
                                             'dbhost=s' => \$dbhost,
                                             'dbname=s' => \$dbname,
                                             'dbpasswd=s' => \$dbpasswd,
@@ -303,8 +304,13 @@ if ($verbose)
 	print STDERR "$progname: started at " . localtime($now) . "\n";
 }
 
+require "DBD/$dbscheme.pm";
+
 my $dbi_dsn = "DBI:" . $dbscheme . ":database=" . $dbname .
-              ";host=" . $dbhost . ";port=" . $dbport;
+              ";host=" . $dbhost;
+if ($dbport != $def_dbport) {
+    $dbi_dsn .= ";port=" . $dbport;
+}
 
 $dbi_h = DBI->connect($dbi_dsn, $dbuser, $dbpasswd, { PrintError => 0 });
 if (!defined($dbi_h))


### PR DESCRIPTION
The first commit here is a patch I submitted years ago in #196 for MariaDB compatibility which was never merged.

The second is a non-functional Perl formatting nit to make perl-mode in Emacs do indentation properly.

The third is the "juicy" one, adding support for MariaDB to the report Perl scripts. See the commit message for that one for details of why this is necessary and appropriate.