### PR TITLE
Feature print runtime of opendmarc-expire

### DIFF
--- a/reports/opendmarc-expire.in
+++ b/reports/opendmarc-expire.in
@@ -54,6 +54,8 @@ my $def_maxage    = 180;
 my $rows;
 my $maxage;
 
+my $now = time();
+
 ###
 ### NO user-serviceable parts beyond this point
 ###
@@ -192,7 +194,7 @@ if ($maxage <= 0)
 
 if ($verbose)
 {
-	print STDERR "$progname: started at " . localtime() . "\n";
+	print STDERR "$progname: started at " . localtime($now) . "\n";
 }
 
 my $dbi_dsn = "DBI:" . $dbscheme . ":database=" . $dbname .
@@ -564,7 +566,7 @@ if ($alltables)
 
 if ($verbose)
 {
-	print STDERR "$progname: terminating at " . localtime() . "\n";
+	print STDERR "$progname: terminating at " . localtime() . "(duration=" . scalar(time() - $now) . ")\n";
 }
 
 $dbi_h->disconnect;

--- a/reports/opendmarc-expire.in
+++ b/reports/opendmarc-expire.in
@@ -566,7 +566,7 @@ if ($alltables)
 
 if ($verbose)
 {
-	print STDERR "$progname: terminating at " . localtime() . "(duration=" . scalar(time() - $now) . ")\n";
+	print STDERR "$progname: terminating at " . localtime() . " (duration=" . scalar(time() - $now) . ")\n";
 }
 
 $dbi_h->disconnect;

--- a/reports/opendmarc-reports.in
+++ b/reports/opendmarc-reports.in
@@ -1061,7 +1061,7 @@ $dbi_s->finish;
 
 if ($verbose)
 {
-	print STDERR "$progname: terminating at " . localtime() . "(duration=" . scalar(time() - $now) . ")\n";
+	print STDERR "$progname: terminating at " . localtime() . " (duration=" . scalar(time() - $now) . ")\n";
 }
 
 $dbi_h->disconnect;

--- a/reports/opendmarc-reports.in
+++ b/reports/opendmarc-reports.in
@@ -1061,7 +1061,7 @@ $dbi_s->finish;
 
 if ($verbose)
 {
-	print STDERR "$progname: terminating at " . localtime() . "\n";
+	print STDERR "$progname: terminating at " . localtime() . "(duration=" . scalar(time() - $now) . ")\n";
 }
 
 $dbi_h->disconnect;


### PR DESCRIPTION
I added this code to let opendmarc-expire print how long it runs. I find it useful the get that information get logged.  
It's running since long time in production here.

@thegushi feel free to discard this merge request if you don't think it's useful for others