### PR TITLE
adding SMTP SASL authentication to opendmarc-reports sending script

### DIFF
--- a/reports/opendmarc-reports.8.in
+++ b/reports/opendmarc-reports.8.in
@@ -93,6 +93,20 @@ Causes reports to be sent by transmitting them using SMTP to the specified
 .I port.
 The default is 25.
 .TP
+.I --smtp-user=username
+Used with 
+.I --smtp-pass
+Causes reports to be sent with a SMTP SASL authenticated session using 
+.I username
+as login.
+.TP
+.I --smtp-pass=password
+Used with 
+.I --smtp-user
+Causes reports to be sent with a SMTP SASL authenticated session using 
+.I password
+as password.
+.TP
 .I --utc
 Instructs the database to change to the UTC timezone when generating output.
 Otherwise, the database default is used.

--- a/reports/opendmarc-reports.in
+++ b/reports/opendmarc-reports.in
@@ -140,6 +140,8 @@ my $repemail     = "postmaster@" . $repdom;
 
 my $smtp_server  = '127.0.0.1';
 my $smtp_port    = 25;
+my $smtp_user    = undef;
+my $smtp_pass    = undef;
 my $smtp;
 
 my $answer;
@@ -169,6 +171,8 @@ sub usage
 	print STDERR "\t--report-org       reporting organization [$repdom]\n";
 	print STDERR "\t--smtp-port        smtp server port [$smtp_port]\n";
 	print STDERR "\t--smtp-server      smtp server [$smtp_server]\n";
+	print STDERR "\t--smtp-user        smtp SASL username\n";
+	print STDERR "\t--smtp-pass        smtp SASL password\n";
 	print STDERR "\t--test             don't send reports\n";
 	print STDERR "\t                   (implies --keepfiles --noupdate)\n";
 	print STDERR "\t--utc              operate in UTC\n";
@@ -198,6 +202,8 @@ my $opt_retval = &Getopt::Long::GetOptions ('day!' => \$daybound,
                                             'report-org=s' => \$repdom,
                                             'smtp-server=s' => \$smtp_server,
                                             'smtp-port=i' => \$smtp_port,
+                                            'smtp-user=s' => \$smtp_user,
+                                            'smtp-pass=s' => \$smtp_pass,
                                             'update!' => \$doupdate,
                                             'utc!' => \$use_utc,
                                             'verbose+' => \$verbose,
@@ -406,6 +412,17 @@ if (!defined($smtp))
 {
 	print STDERR "$progname: open SMTP server $smtp_server:$smtp_port failed\n";
 	exit(1);
+}
+
+
+if ( defined ($smtp_user) && defined ($smtp_pass) )
+{
+	# perform STARTTLS initialization
+	if (! $smtp->auth($smtp_user,$smtp_pass) )
+	{
+		print STDERR "$progname: SASL Auth for user $smtp_user on $smtp_server:$smtp_port failed\n";
+		exit(1);
+	}
 }
 
 foreach (@$domainset)


### PR DESCRIPTION
I noticed opendmark report sending script is lacking of SASL SMTP autentication support wich is a quite trivial change from actual code.
Could you please consider to add it ?