### PR TITLE
Fix(configure): Correctly persist SPF include and library paths

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -334,11 +334,8 @@ then
 	then
 		AC_DEFINE(HAVE_SPF2_H, 1,
 			[Define to 1 if you have libspf2's `spf.h'])
-		spf2_include="-I $SPF2_INCLUDE"
-		saved_CFLAGS="$CFLAGS"
-		saved_LDFLAGS="$LDFLAGS"
-		CFLAGS="$spf2_include $saved_CFLAGS"
-		LDFLAGS="$saved_LDFLAGS -L${SPF2_LIB}"
+		CPPFLAGS="$CPPFLAGS -I${SPF2_INCLUDE}"
+		LDFLAGS="$LDFLAGS -L${SPF2_LIB}"
 	fi
 	AC_SEARCH_LIBS(SPF_record_new, spf2)
 	AC_SEARCH_LIBS(SPF_server_new, spf2)


### PR DESCRIPTION
The previous logic for detecting libspf2 temporarily modified the `CFLAGS` and `LDFLAGS` shell variables. While this was sufficient for the internal `AC_SEARCH_LIBS` check to pass, these modifications were not propagated into the final generated Makefiles.

This caused build failures in strict environments (e.g., Fedora/EPEL rpmbuild) where `CFLAGS` is pre-populated with distribution-wide policies. The script's changes were lost, leading to compiler errors like `"spf.h: No such file or directory"` during the `make` stage.

This commit fixes the issue by appending the SPF include and library paths to the standard `CPPFLAGS` and `LDFLAGS` variables, respectively.

This commit is required for recent Fedora versions to build.