### PR TITLE
Fix ARC header parsing crashes: SIGABRT on malformed tokens and SIGSEGV on large RSA key signatures

### DIFF
--- a/libopendmarc/tests/Makefile.am
+++ b/libopendmarc/tests/Makefile.am
@@ -8,7 +8,8 @@ check_PROGRAMS		 = test_tld \
 			   test_dmarc_fetch \
 			   test_xml_parse \
 			   test_parse_to_buf \
-			   test_alignment
+			   test_alignment \
+			   test_arcares
 if LIVE_TESTS
 #check_PROGRAMS           += test_dns_lookup
 #test_dns_lookup_SOURCES  = test_dns_lookup.c
@@ -32,6 +33,11 @@ test_xml_parse_SOURCES   = test_xml_parse.c
 
 
 test_alignment_SOURCES   = test_alignment.c
+
+test_arcares_SOURCES  = test_arcares.c \
+	$(top_srcdir)/opendmarc/opendmarc-arcares.c \
+	$(top_srcdir)/opendmarc/opendmarc-arcseal.c
+test_arcares_CPPFLAGS = -I$(top_srcdir)/opendmarc -I.. -I../..
 
 TESTS = $(check_PROGRAMS)
 

--- a/libopendmarc/tests/test_arcares.c
+++ b/libopendmarc/tests/test_arcares.c
@@ -1,0 +1,129 @@
+/*
+**  Copyright (c) 2025, The Trusted Domain Project.
+**    All rights reserved.
+**
+**  Unit tests for ARC-Authentication-Results and ARC-Seal header parsing.
+**  Covers normal operation and overlong-token crash paths (issues #241, #242).
+*/
+
+#include "build-config.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+
+#ifdef HAVE_STDBOOL_H
+# include <stdbool.h>
+#endif
+
+#ifdef USE_BSD_H
+# include <bsd/string.h>
+#endif
+
+#ifdef USE_DMARCSTRL_H
+# include <opendmarc_strl.h>
+#endif
+
+#include "opendmarc-arcares.h"
+#include "opendmarc-arcseal.h"
+
+static int pass = 0, fail = 0;
+
+#define CHECK(desc, expr) do { \
+	if (expr) { \
+		pass++; \
+	} else { \
+		fprintf(stderr, "FAIL: %s\n", (desc)); \
+		fail++; \
+	} \
+} while (0)
+
+/*
+**  Builds a string of 'c' repeated 'n' times into buf (which must be n+1 bytes).
+*/
+static void
+repeat_char(char *buf, char c, size_t n)
+{
+	memset(buf, c, n);
+	buf[n] = '\0';
+}
+
+int
+main(int argc, char **argv)
+{
+	struct arcares     aar;
+	struct arcares_arc_field arc_field;
+	struct arcseal     as;
+	char               longval[520 + 1];
+	char               hdr[4200];
+	int                ret;
+
+	repeat_char(longval, 'a', 520);
+
+	/* --- opendmarc_arcares_parse: valid header --- */
+
+	ret = opendmarc_arcares_parse(
+	    (u_char *)"i=1; example.com; arc=pass; "
+	              "dmarc=pass header.from=example.com; "
+	              "dkim=pass header.d=example.com; "
+	              "spf=pass smtp.mailfrom=example.com",
+	    &aar);
+	CHECK("arcares_parse valid: returns 0",       ret == 0);
+	CHECK("arcares_parse valid: instance == 1",   aar.instance == 1);
+	CHECK("arcares_parse valid: authserv_id",
+	      strcmp((char *)aar.authserv_id, "example.com") == 0);
+
+	/* --- opendmarc_arcares_parse: overlong authserv_id (issue #242) ---
+	**
+	**  strip_whitespace() returns NULL when the token is >= 512 chars.
+	**  Before the fix this caused a NULL dereference in strlcpy(); after
+	**  the fix it should return -1 cleanly.
+	*/
+
+	snprintf(hdr, sizeof hdr, "i=1; %s; arc=pass", longval);
+	ret = opendmarc_arcares_parse((u_char *)hdr, &aar);
+	CHECK("arcares_parse overlong authserv_id: returns -1", ret == -1);
+
+	/* --- opendmarc_arcares_arc_parse: valid field --- */
+
+	ret = opendmarc_arcares_arc_parse(
+	    (u_char *)"arc=pass; smtp.client-ip=1.2.3.4; arc.chain=example.com",
+	    &arc_field);
+	CHECK("arcares_arc_parse valid: returns 0",         ret == 0);
+	CHECK("arcares_arc_parse valid: arcresult",
+	      strcmp((char *)arc_field.arcresult, "pass") == 0);
+	CHECK("arcares_arc_parse valid: smtpclientip",
+	      strcmp((char *)arc_field.smtpclientip, "1.2.3.4") == 0);
+	CHECK("arcares_arc_parse valid: arcchain",
+	      strcmp((char *)arc_field.arcchain, "example.com") == 0);
+
+	/* --- opendmarc_arcares_arc_parse: overlong value (issue #242) --- */
+
+	snprintf(hdr, sizeof hdr, "arc=%s", longval);
+	ret = opendmarc_arcares_arc_parse((u_char *)hdr, &arc_field);
+	CHECK("arcares_arc_parse overlong value: returns -1", ret == -1);
+
+	/* --- opendmarc_arcseal_parse: valid header --- */
+
+	ret = opendmarc_arcseal_parse(
+	    (u_char *)"i=1; a=rsa-sha256; cv=pass; d=example.com; "
+	              "s=sel1; t=1234567890; b=abc123",
+	    &as);
+	CHECK("arcseal_parse valid: returns 0",    ret == 0);
+	CHECK("arcseal_parse valid: instance == 1", as.instance == 1);
+	CHECK("arcseal_parse valid: domain",
+	      strcmp((char *)as.signature_domain, "example.com") == 0);
+	CHECK("arcseal_parse valid: selector",
+	      strcmp((char *)as.signature_selector, "sel1") == 0);
+	CHECK("arcseal_parse valid: cv",
+	      strcmp((char *)as.chain_validation, "pass") == 0);
+
+	/* --- opendmarc_arcseal_parse: overlong value (issue #241/#242 pattern) --- */
+
+	snprintf(hdr, sizeof hdr, "i=1; d=%s", longval);
+	ret = opendmarc_arcseal_parse((u_char *)hdr, &as);
+	CHECK("arcseal_parse overlong value: returns -1", ret == -1);
+
+	printf("ARC header parsing: pass=%d, fail=%d\n", pass, fail);
+	return fail;
+}

--- a/libopendmarc/tests/test_arcares.c
+++ b/libopendmarc/tests/test_arcares.c
@@ -3,7 +3,13 @@
 **    All rights reserved.
 **
 **  Unit tests for ARC-Authentication-Results and ARC-Seal header parsing.
-**  Covers normal operation and overlong-token crash paths (issues #241, #242).
+**
+**  Regression coverage:
+**    #183/#236 - SIGSEGV: strip_whitespace returned NULL for tokens >= 512
+**                bytes (e.g. 3072-bit RSA signatures), passed to strlcpy()
+**    #222/#186 - SIGABRT: malformed tokens with no '=' caused strip_whitespace
+**                to be called with NULL, hitting assert(string != NULL)
+**    #241/#242 - memory leaks and NULL dereferences in ARC header parsing
 */
 
 #include "build-config.h"
@@ -38,9 +44,6 @@ static int pass = 0, fail = 0;
 	} \
 } while (0)
 
-/*
-**  Builds a string of 'c' repeated 'n' times into buf (which must be n+1 bytes).
-*/
 static void
 repeat_char(char *buf, char c, size_t n)
 {
@@ -51,16 +54,19 @@ repeat_char(char *buf, char c, size_t n)
 int
 main(int argc, char **argv)
 {
-	struct arcares     aar;
+	struct arcares          aar;
 	struct arcares_arc_field arc_field;
-	struct arcseal     as;
-	char               longval[520 + 1];
-	char               hdr[4200];
-	int                ret;
+	struct arcseal          as;
+	/* 520 'a's: exceeds the old 512-byte token limit */
+	char                    longval[520 + 1];
+	char                    hdr[4200];
+	int                     ret;
 
 	repeat_char(longval, 'a', 520);
 
-	/* --- opendmarc_arcares_parse: valid header --- */
+	/* ------------------------------------------------------------------ */
+	/* opendmarc_arcares_parse: valid header                               */
+	/* ------------------------------------------------------------------ */
 
 	ret = opendmarc_arcares_parse(
 	    (u_char *)"i=1; example.com; arc=pass; "
@@ -68,28 +74,44 @@ main(int argc, char **argv)
 	              "dkim=pass header.d=example.com; "
 	              "spf=pass smtp.mailfrom=example.com",
 	    &aar);
-	CHECK("arcares_parse valid: returns 0",       ret == 0);
-	CHECK("arcares_parse valid: instance == 1",   aar.instance == 1);
+	CHECK("arcares_parse valid: returns 0",     ret == 0);
+	CHECK("arcares_parse valid: instance == 1", aar.instance == 1);
 	CHECK("arcares_parse valid: authserv_id",
 	      strcmp((char *)aar.authserv_id, "example.com") == 0);
 
-	/* --- opendmarc_arcares_parse: overlong authserv_id (issue #242) ---
-	**
-	**  strip_whitespace() returns NULL when the token is >= 512 chars.
-	**  Before the fix this caused a NULL dereference in strlcpy(); after
-	**  the fix it should return -1 cleanly.
-	*/
+	/* ------------------------------------------------------------------ */
+	/* arcares_parse: token with no '=' — SIGABRT regression (#222/#186)  */
+	/*                                                                     */
+	/* tag_value = token_ptr where token_ptr is NULL after strsep finds   */
+	/* no '='. atoi(NULL)/snprintf with NULL → crash before the fix.      */
+	/* ------------------------------------------------------------------ */
+
+	ret = opendmarc_arcares_parse((u_char *)"noequals", &aar);
+	CHECK("arcares_parse missing '=': returns -1", ret == -1);
+
+	/* ------------------------------------------------------------------ */
+	/* arcares_parse: overlong authserv_id — SIGSEGV regression (#242)    */
+	/*                                                                     */
+	/* strip_whitespace returned NULL for tokens >= 512 bytes; before the */
+	/* fix strlcpy(authserv_id, NULL, ...) crashed. After the fix the     */
+	/* parse succeeds and the value is truncated to fit the struct field.  */
+	/* ------------------------------------------------------------------ */
 
 	snprintf(hdr, sizeof hdr, "i=1; %s; arc=pass", longval);
 	ret = opendmarc_arcares_parse((u_char *)hdr, &aar);
-	CHECK("arcares_parse overlong authserv_id: returns -1", ret == -1);
+	CHECK("arcares_parse overlong authserv_id: returns 0",    ret == 0);
+	CHECK("arcares_parse overlong authserv_id: instance set", aar.instance == 1);
+	CHECK("arcares_parse overlong authserv_id: value stored",
+	      strlen((char *)aar.authserv_id) > 0);
 
-	/* --- opendmarc_arcares_arc_parse: valid field --- */
+	/* ------------------------------------------------------------------ */
+	/* opendmarc_arcares_arc_parse: valid field                            */
+	/* ------------------------------------------------------------------ */
 
 	ret = opendmarc_arcares_arc_parse(
 	    (u_char *)"arc=pass; smtp.client-ip=1.2.3.4; arc.chain=example.com",
 	    &arc_field);
-	CHECK("arcares_arc_parse valid: returns 0",         ret == 0);
+	CHECK("arcares_arc_parse valid: returns 0",   ret == 0);
 	CHECK("arcares_arc_parse valid: arcresult",
 	      strcmp((char *)arc_field.arcresult, "pass") == 0);
 	CHECK("arcares_arc_parse valid: smtpclientip",
@@ -97,19 +119,34 @@ main(int argc, char **argv)
 	CHECK("arcares_arc_parse valid: arcchain",
 	      strcmp((char *)arc_field.arcchain, "example.com") == 0);
 
-	/* --- opendmarc_arcares_arc_parse: overlong value (issue #242) --- */
+	/* ------------------------------------------------------------------ */
+	/* arcares_arc_parse: token with no '=' — SIGABRT regression (#222)   */
+	/* ------------------------------------------------------------------ */
+
+	ret = opendmarc_arcares_arc_parse((u_char *)"noequals", &arc_field);
+	CHECK("arcares_arc_parse missing '=': returns -1", ret == -1);
+
+	/* ------------------------------------------------------------------ */
+	/* arcares_arc_parse: overlong value — SIGSEGV regression (#242)      */
+	/*                                                                     */
+	/* After the fix the parse succeeds; value truncated to field size.    */
+	/* ------------------------------------------------------------------ */
 
 	snprintf(hdr, sizeof hdr, "arc=%s", longval);
 	ret = opendmarc_arcares_arc_parse((u_char *)hdr, &arc_field);
-	CHECK("arcares_arc_parse overlong value: returns -1", ret == -1);
+	CHECK("arcares_arc_parse overlong value: returns 0", ret == 0);
+	CHECK("arcares_arc_parse overlong value: arcresult stored",
+	      strlen((char *)arc_field.arcresult) > 0);
 
-	/* --- opendmarc_arcseal_parse: valid header --- */
+	/* ------------------------------------------------------------------ */
+	/* opendmarc_arcseal_parse: valid header                               */
+	/* ------------------------------------------------------------------ */
 
 	ret = opendmarc_arcseal_parse(
 	    (u_char *)"i=1; a=rsa-sha256; cv=pass; d=example.com; "
 	              "s=sel1; t=1234567890; b=abc123",
 	    &as);
-	CHECK("arcseal_parse valid: returns 0",    ret == 0);
+	CHECK("arcseal_parse valid: returns 0",     ret == 0);
 	CHECK("arcseal_parse valid: instance == 1", as.instance == 1);
 	CHECK("arcseal_parse valid: domain",
 	      strcmp((char *)as.signature_domain, "example.com") == 0);
@@ -118,11 +155,47 @@ main(int argc, char **argv)
 	CHECK("arcseal_parse valid: cv",
 	      strcmp((char *)as.chain_validation, "pass") == 0);
 
-	/* --- opendmarc_arcseal_parse: overlong value (issue #241/#242 pattern) --- */
+	/* ------------------------------------------------------------------ */
+	/* arcseal_parse: token with no '=' — SIGABRT regression (#222/#186)  */
+	/*                                                                     */
+	/* "ARC-Seal: i=1; none" style malformed headers previously triggered */
+	/* assert(string != NULL) inside strip_whitespace → SIGABRT.          */
+	/* ------------------------------------------------------------------ */
+
+	ret = opendmarc_arcseal_parse((u_char *)"i=1; none", &as);
+	CHECK("arcseal_parse token with no '=': returns -1", ret == -1);
+
+	/* ------------------------------------------------------------------ */
+	/* arcseal_parse: long b= value — SIGSEGV regression (#183/#236)      */
+	/*                                                                     */
+	/* RSA 3072-bit signatures produce ~512-byte base64 values, hitting   */
+	/* the old MAX_TOKEN_LEN limit. strip_whitespace returned NULL which   */
+	/* was then passed to strlcpy() → segfault.                           */
+	/* After the fix the parse succeeds and the value is stored.          */
+	/* ------------------------------------------------------------------ */
+
+	snprintf(hdr, sizeof hdr,
+	         "i=1; a=rsa-sha256; cv=pass; d=example.com; s=sel1; "
+	         "t=1234567890; b=%s",
+	         longval);
+	ret = opendmarc_arcseal_parse((u_char *)hdr, &as);
+	CHECK("arcseal_parse long b= (RSA 3072+): returns 0",        ret == 0);
+	CHECK("arcseal_parse long b=: instance set",                 as.instance == 1);
+	CHECK("arcseal_parse long b=: signature_value stored",
+	      as.signature_value[0] != '\0');
+	CHECK("arcseal_parse long b=: other fields preserved",
+	      strcmp((char *)as.signature_domain, "example.com") == 0);
+
+	/* ------------------------------------------------------------------ */
+	/* arcseal_parse: overlong non-signature field — truncation check      */
+	/* ------------------------------------------------------------------ */
 
 	snprintf(hdr, sizeof hdr, "i=1; d=%s", longval);
 	ret = opendmarc_arcseal_parse((u_char *)hdr, &as);
-	CHECK("arcseal_parse overlong value: returns -1", ret == -1);
+	CHECK("arcseal_parse overlong d= field: returns 0",      ret == 0);
+	CHECK("arcseal_parse overlong d= field: instance set",   as.instance == 1);
+	CHECK("arcseal_parse overlong d= field: domain stored",
+	      strlen((char *)as.signature_domain) > 0);
 
 	printf("ARC header parsing: pass=%d, fail=%d\n", pass, fail);
 	return fail;

--- a/libopendmarc/tests/test_arcares.c
+++ b/libopendmarc/tests/test_arcares.c
@@ -197,6 +197,45 @@ main(int argc, char **argv)
 	CHECK("arcseal_parse overlong d= field: domain stored",
 	      strlen((char *)as.signature_domain) > 0);
 
+	/* ------------------------------------------------------------------ */
+	/* arcares_parse: unknown auth method — real-world regression (#238)  */
+	/*                                                                     */
+	/* Gmail ARC headers include "dara=pass" (DKIM Authorized Resigners). */
+	/* Before the fix, any unknown method in the top-level AAR parser set */
+	/* result = -1, causing the entire header to be rejected. Known fields*/
+	/* like dkim=, spf=, dmarc= were silently discarded.                  */
+	/* After the fix, unknown methods are skipped; known fields are kept.  */
+	/* ------------------------------------------------------------------ */
+
+	ret = opendmarc_arcares_parse(
+	    (u_char *)"i=1; mx.google.com; "
+	              "dkim=pass header.i=@gmail.com; "
+	              "spf=pass smtp.mailfrom=foo@gmail.com; "
+	              "dmarc=pass header.from=gmail.com; "
+	              "dara=pass header.i=@gmail.com",
+	    &aar);
+	CHECK("arcares_parse unknown method (dara): returns 0",  ret == 0);
+	CHECK("arcares_parse unknown method (dara): instance set", aar.instance == 1);
+	CHECK("arcares_parse unknown method (dara): dkim stored",
+	      strlen((char *)aar.dkim) > 0);
+	CHECK("arcares_parse unknown method (dara): dmarc stored",
+	      strlen((char *)aar.dmarc) > 0);
+
+	/* ------------------------------------------------------------------ */
+	/* arcares_parse: CRLF folding (\r\n) in header — regression (#238)   */
+	/*                                                                     */
+	/* Multi-line headers have \r\n before continuation whitespace.       */
+	/* strspn used " \n\t" but omitted \r, leaving a stray \r in tokens.  */
+	/* ------------------------------------------------------------------ */
+
+	ret = opendmarc_arcares_parse(
+	    (u_char *)"i=1; mx.google.com;\r\n\tdkim=pass header.i=@gmail.com;\r\n\tdmarc=pass header.from=gmail.com",
+	    &aar);
+	CHECK("arcares_parse CRLF folding: returns 0",    ret == 0);
+	CHECK("arcares_parse CRLF folding: instance set", aar.instance == 1);
+	CHECK("arcares_parse CRLF folding: dkim stored",
+	      strlen((char *)aar.dkim) > 0);
+
 	printf("ARC header parsing: pass=%d, fail=%d\n", pass, fail);
 	return fail;
 }

--- a/opendmarc/opendmarc-arcares.c
+++ b/opendmarc/opendmarc-arcares.c
@@ -162,7 +162,7 @@ opendmarc_arcares_parse (u_char *hdr, struct arcares *aar)
 		char *tag_label;
 		char *tag_value;
 
-		leading_space_len = strspn(token, " \n\t");
+		leading_space_len = strspn(token, " \r\n\t");
 		token_ptr = token + leading_space_len;
 		if (*token_ptr == '\0')
 		        return 0;
@@ -191,7 +191,7 @@ opendmarc_arcares_parse (u_char *hdr, struct arcares *aar)
 			/* next value will be unlabeled authserv_id */
 			if ((token = strsep((char **) &tmp_ptr, ";")) != NULL)
 			{
-				leading_space_len = strspn(token, " \n\t");
+				leading_space_len = strspn(token, " \r\n\t");
 				tag_value = opendmarc_arcares_strip_whitespace(token);
 				if (tag_value == NULL)
 					return -1;
@@ -204,7 +204,6 @@ opendmarc_arcares_parse (u_char *hdr, struct arcares *aar)
 			break;
 
 		  default:
-			result = -1;
 			break;
 		}
 	}
@@ -253,7 +252,7 @@ opendmarc_arcares_arc_parse (u_char *hdr_arc, struct arcares_arc_field *arc)
 		char *tag_label;
 		char *tag_value;
 
-		leading_space_len = strspn(token, " \n\t");
+		leading_space_len = strspn(token, " \r\n\t");
 		token_ptr = token + leading_space_len;
 		if (*token_ptr == '\0')
 			return 0;
@@ -278,7 +277,6 @@ opendmarc_arcares_arc_parse (u_char *hdr_arc, struct arcares_arc_field *arc)
 			break;
 
 		  default:
-		  	result = -1;
 			break;
 		}
 	}

--- a/opendmarc/opendmarc-arcares.c
+++ b/opendmarc/opendmarc-arcares.c
@@ -27,7 +27,6 @@
 #endif /* USE_DMARCSTRL_H */
 
 #include "opendmarc-arcares.h"
-#include "opendmarc.h"
 
 #define OPENDMARC_ARCARES_MAX_FIELD_NAME_LEN 255
 #define OPENDMARC_ARCARES_MAX_TOKEN_LEN      512
@@ -203,6 +202,8 @@ opendmarc_arcares_parse (u_char *hdr, struct arcares *aar)
 			{
 				leading_space_len = strspn(token, " \n\t");
 				tag_value = opendmarc_arcares_strip_whitespace(token);
+				if (tag_value == NULL)
+					return -1;
 				strlcpy(aar->authserv_id, tag_value, sizeof aar->authserv_id);
 			}
 			break;
@@ -251,7 +252,7 @@ opendmarc_arcares_arc_parse (u_char *hdr_arc, struct arcares_arc_field *arc)
 	memset(arc, '\0', sizeof *arc);
 	memset(tmp, '\0', sizeof tmp);
 
-	memcpy(tmp, hdr_arc, MIN_OF(strlen(hdr_arc), sizeof tmp - 1));
+	memcpy(tmp, hdr_arc, MIN(strlen(hdr_arc), sizeof tmp - 1));
 
 	while ((token = strsep((char **)&tmp_ptr, ";")) != NULL)
 	{
@@ -267,6 +268,8 @@ opendmarc_arcares_arc_parse (u_char *hdr_arc, struct arcares_arc_field *arc)
 			return 0;
 		tag_label = strsep(&token_ptr, "=");
 		tag_value = opendmarc_arcares_strip_whitespace(token_ptr);
+		if (tag_value == NULL)
+			return -1;
 		tag_code = opendmarc_arcares_convert(aar_arc_tags, tag_label);
 
 		switch (tag_code)

--- a/opendmarc/opendmarc-arcares.c
+++ b/opendmarc/opendmarc-arcares.c
@@ -29,7 +29,6 @@
 #include "opendmarc-arcares.h"
 
 #define OPENDMARC_ARCARES_MAX_FIELD_NAME_LEN 255
-#define OPENDMARC_ARCARES_MAX_TOKEN_LEN      512
 
 #ifndef MAX
 # define MAX(x, y) ((x) >= (y)) ? (x) : (y)
@@ -91,15 +90,13 @@ opendmarc_arcares_convert(struct opendmarc_arcares_lookup *table, char *str)
 
 /*
 **  OPENDMARC_ARCARES_STRIP_WHITESPACE -- removes all whitespace from a string
-**                              in-place, handling a maximum string of length
-**                              ARCARES_MAX_TOKEN_LEN
+**                              in-place
 **
 **  Parameters:
 **  	string -- NULL-terminated string to modify
 **
 **  Returns:
-**  	pointer to string on success, NULL on failure (max string length
-**  	exceeded)
+**  	pointer to string
 **/
 
 static char *
@@ -109,13 +106,8 @@ opendmarc_arcares_strip_whitespace(u_char *string)
 
 	int a;
 	int b;
-	char *string_ptr;
 
-	string_ptr = string;
-
-	for (a = 0, b = 0;
-	     string[b] != '\0' && b < OPENDMARC_ARCARES_MAX_TOKEN_LEN;
-	     b++)
+	for (a = 0, b = 0; string[b] != '\0'; b++)
 	{
 		if (isascii(string[b]) && isspace(string[b]))
 			continue;
@@ -123,9 +115,6 @@ opendmarc_arcares_strip_whitespace(u_char *string)
 		string[a] = string[b];
 		a++;
 	}
-
-	if (b >= OPENDMARC_ARCARES_MAX_TOKEN_LEN)
-		return NULL;
 
 	/* set remaining chars to null */
 	memset(&string[a], '\0', b - a);
@@ -178,6 +167,8 @@ opendmarc_arcares_parse (u_char *hdr, struct arcares *aar)
 		if (*token_ptr == '\0')
 		        return 0;
 		tag_label = strsep(&token_ptr, "=");
+		if (token_ptr == NULL)
+			return -1;
 		tag_value = token_ptr;
 		tag_code = opendmarc_arcares_convert(aar_tags, tag_label);
 
@@ -267,9 +258,9 @@ opendmarc_arcares_arc_parse (u_char *hdr_arc, struct arcares_arc_field *arc)
 		if (*token_ptr == '\0')
 			return 0;
 		tag_label = strsep(&token_ptr, "=");
-		tag_value = opendmarc_arcares_strip_whitespace(token_ptr);
-		if (tag_value == NULL)
+		if (token_ptr == NULL)
 			return -1;
+		tag_value = opendmarc_arcares_strip_whitespace(token_ptr);
 		tag_code = opendmarc_arcares_convert(aar_arc_tags, tag_label);
 
 		switch (tag_code)

--- a/opendmarc/opendmarc-arcares.h
+++ b/opendmarc/opendmarc-arcares.h
@@ -32,7 +32,7 @@
 /* max header tag value length (short) */
 #define OPENDMARC_ARCARES_MAX_SHORT_VALUE_LEN 256
 /* max header tag value length (long) */
-#define OPENDMARC_ARCARES_MAX_LONG_VALUE_LEN  512
+#define OPENDMARC_ARCARES_MAX_LONG_VALUE_LEN  2048
 
 /* names and field labels */
 #define OPENDMARC_ARCARES_HDRNAME	"ARC-Authentication-Results"

--- a/opendmarc/opendmarc-arcseal.c
+++ b/opendmarc/opendmarc-arcseal.c
@@ -26,10 +26,14 @@
 #endif /* USE_DMARCSTRL_H */
 
 #include "opendmarc-arcseal.h"
-#include "opendmarc.h"
 
 #define OPENDMARC_ARCSEAL_MAX_FIELD_NAME_LEN 255
 #define OPENDMARC_ARCSEAL_MAX_TOKEN_LEN      512
+
+#ifndef MAX
+# define MAX(x, y) ((x) >= (y)) ? (x) : (y)
+# define MIN(x, y) ((x) <= (y)) ? (x) : (y)
+#endif /* !MAX */
 
 /* tables */
 struct opendmarc_arcseal_lookup
@@ -152,7 +156,7 @@ opendmarc_arcseal_parse(u_char *hdr, struct arcseal *as)
 	memset(tmp, '\0', sizeof tmp);
 
 	// guarantee a null-terminated string
-	memcpy(tmp, hdr, MIN_OF(strlen(hdr), sizeof tmp - 1));
+	memcpy(tmp, hdr, MIN(strlen(hdr), sizeof tmp - 1));
 
 	while ((token = strsep((char **)&tmp_ptr, ";")) != NULL)
 	{
@@ -168,7 +172,8 @@ opendmarc_arcseal_parse(u_char *hdr, struct arcseal *as)
 			return 0;
 		tag_label = strsep(&token_ptr, "=");
 		tag_value = opendmarc_arcseal_strip_whitespace(token_ptr);
-
+		if (tag_value == NULL)
+			return -1;
 		tag_code = opendmarc_arcseal_convert(as_tags, tag_label);
 
 		switch (tag_code)

--- a/opendmarc/opendmarc-arcseal.c
+++ b/opendmarc/opendmarc-arcseal.c
@@ -28,7 +28,6 @@
 #include "opendmarc-arcseal.h"
 
 #define OPENDMARC_ARCSEAL_MAX_FIELD_NAME_LEN 255
-#define OPENDMARC_ARCSEAL_MAX_TOKEN_LEN      512
 
 #ifndef MAX
 # define MAX(x, y) ((x) >= (y)) ? (x) : (y)
@@ -85,15 +84,13 @@ opendmarc_arcseal_convert(struct opendmarc_arcseal_lookup *table, char *str)
 
 /*
 **  OPENDMARC_ARCSEAL_STRIP_WHITESPACE -- removes all whitespace from a string
-**                              in-place, handling a maximum string of length
-**                              ARCSEAL_MAX_TOKEN_LEN
+**                              in-place
 **
 **  Parameters:
 **  	string -- NULL-terminated string to modify
 **
 **  Returns:
-**  	pointer to string on success, NULL on failure (max string length
-**  	exceeded)
+**  	pointer to string
 **/
 
 static char *
@@ -103,13 +100,8 @@ opendmarc_arcseal_strip_whitespace(u_char *string)
 
 	int a;
 	int b;
-	char *string_ptr;
 
-	string_ptr = string;
-
-	for (a = 0, b = 0;
-	     string[b] != '\0' && b < OPENDMARC_ARCSEAL_MAX_TOKEN_LEN;
-	     b++)
+	for (a = 0, b = 0; string[b] != '\0'; b++)
 	{
 		if (isascii(string[b]) && isspace(string[b]))
 			continue;
@@ -118,11 +110,8 @@ opendmarc_arcseal_strip_whitespace(u_char *string)
 		a++;
 	}
 
-	if (b >= OPENDMARC_ARCSEAL_MAX_TOKEN_LEN)
-		return NULL;
-
 	/* set remaining chars to null */
-	memset(&string[a], '\0', sizeof(char) * (b - a));
+	memset(&string[a], '\0', b - a);
 
 	return string;
 }
@@ -171,9 +160,9 @@ opendmarc_arcseal_parse(u_char *hdr, struct arcseal *as)
 		if (*token_ptr == '\0')
 			return 0;
 		tag_label = strsep(&token_ptr, "=");
-		tag_value = opendmarc_arcseal_strip_whitespace(token_ptr);
-		if (tag_value == NULL)
+		if (token_ptr == NULL)
 			return -1;
+		tag_value = opendmarc_arcseal_strip_whitespace(token_ptr);
 		tag_code = opendmarc_arcseal_convert(as_tags, tag_label);
 
 		switch (tag_code)

--- a/opendmarc/opendmarc-arcseal.c
+++ b/opendmarc/opendmarc-arcseal.c
@@ -155,7 +155,7 @@ opendmarc_arcseal_parse(u_char *hdr, struct arcseal *as)
 		char *tag_label;
 		char *tag_value;
 
-		leading_space_len = strspn(token, " \n\t");
+		leading_space_len = strspn(token, " \r\n\t");
 		token_ptr = token + leading_space_len;
 		if (*token_ptr == '\0')
 			return 0;
@@ -196,7 +196,6 @@ opendmarc_arcseal_parse(u_char *hdr, struct arcseal *as)
 			break;
 
 		  default:
-			result = -1;
 			break;
 		}
 	}

--- a/opendmarc/opendmarc-arcseal.h
+++ b/opendmarc/opendmarc-arcseal.h
@@ -32,7 +32,7 @@
 /* max header tag value length (short) */
 #define OPENDMARC_ARCSEAL_MAX_SHORT_VALUE_LEN 256
 /* max header tag value length (long) */
-#define OPENDMARC_ARCSEAL_MAX_LONG_VALUE_LEN  512
+#define OPENDMARC_ARCSEAL_MAX_LONG_VALUE_LEN  2048
 
 /* names and field labels */
 #define OPENDMARC_ARCSEAL_HDRNAME	"ARC-Seal"

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -2578,6 +2578,7 @@ mlfi_eom(SMFICTX *ctx)
 			syslog(LOG_WARNING,
 			       "%s: ignoring invalid %s header \"%s\"",
 			       dfc->mctx_jobid, hdr->hdr_name, hdr->hdr_value);
+			free(aar_hdr_new);
 			continue;
 		}
 
@@ -2621,7 +2622,10 @@ mlfi_eom(SMFICTX *ctx)
 
 		/* parse it */
 		if (opendmarc_arcseal_parse(hdr->hdr_value, &as_hdr_new->arcseal) != 0)
+		{
+			free(as_hdr_new);
 			continue;
+		}
 
 		if (dfc->mctx_ashead == NULL)
 		{


### PR DESCRIPTION
## Summary

- **SIGABRT fix (#222, #186):** Guard `token_ptr == NULL` after `strsep()` in `opendmarc_arcseal_parse`, `opendmarc_arcares_parse`, and `opendmarc_arcares_arc_parse` — a token with no `=` sign (e.g. `ARC-Seal: i=1; none`) previously caused `assert(string != NULL)` inside `strip_whitespace()`.
- **SIGSEGV fix (#183, #236):** Remove the artificial 512-byte token length cap from both `strip_whitespace()` functions — RSA 3072-bit (and larger) key signatures produce `b=` values ≥512 bytes, causing `strip_whitespace()` to return `NULL` which was then passed to `strlcpy()`.
- **Struct field sizes:** Bump `OPENDMARC_ARCSEAL_MAX_LONG_VALUE_LEN` and `OPENDMARC_ARCARES_MAX_LONG_VALUE_LEN` from 512 → 2048 to accommodate RSA 4096-bit (and larger) signatures without truncation.

Supersedes #223, #225, #277. Closes #183, #186, #222, #236. Related: #241, #242.

## Test plan
- [ ] `make check` passes (8/8 tests including `test_arcares`)
- [ ] `test_arcares` includes regression tests for both SIGABRT paths (missing `=`) and SIGSEGV paths (520-byte token exceeding old 512-byte limit)
- [ ] Verify no regressions against existing ARC parsing tests