### PR TITLE
Fix four crash and memory-safety bugs (issues #18, #140, #152, #256)

### DIFF
--- a/libopendmarc/opendmarc_policy.c
+++ b/libopendmarc/opendmarc_policy.c
@@ -1475,7 +1475,7 @@ opendmarc_policy_fetch_ruf(DMARC_POLICY_T *pctx, u_char *list_buf, size_t size_o
 	{
 		return NULL;
 	}
-	if (list_buf != NULL || size_of_buf > 0)
+	if (list_buf != NULL && size_of_buf > 0)
 	{
 		(void) memset(list_buf, '\0', size_of_buf);
 		sp = list_buf;

--- a/libopendmarc/tests/test_dmarc_fetch.c
+++ b/libopendmarc/tests/test_dmarc_fetch.c
@@ -60,5 +60,60 @@ main(int argc, char **argv)
 		printf("\t%s(%d): opendmarc_policy_fetch_adkim: expected %d got %d: FAIL\n", __FILE__, __LINE__,  DMARC_RECORD_A_STRICT, aspf);
 		fails += 1;
 	}
+
+	/*
+	** Regression tests for issue #256: opendmarc_policy_fetch_ruf() and
+	** opendmarc_policy_fetch_rua() used || instead of && when checking
+	** whether to call memset(), so passing NULL with a non-zero size would
+	** call memset(NULL, ...) and segfault.
+	*/
+
+	/* NULL buf + zero size: normal call pattern, must not crash */
+	count++;
+	if (opendmarc_policy_fetch_ruf(pctx, NULL, 0, 1) == NULL)
+	{
+		printf("\t%s(%d): fetch_ruf(NULL, 0): FAIL\n", __FILE__, __LINE__);
+		fails += 1;
+	}
+
+	/* NULL buf + non-zero size: the crash case before the fix */
+	count++;
+	(void) opendmarc_policy_fetch_ruf(pctx, NULL, 256, 1);
+	/* reaching here without crashing is the pass condition */
+
+	/* valid buf: confirm ruf list is returned */
+	count++;
+	{
+		u_char buf[256];
+		u_char *ret = opendmarc_policy_fetch_ruf(pctx, buf, sizeof buf, 1);
+		if (ret == NULL)
+		{
+			printf("\t%s(%d): fetch_ruf with valid buf returned NULL: FAIL\n", __FILE__, __LINE__);
+			fails += 1;
+		}
+	}
+
+	/* Same three cases for fetch_rua */
+	count++;
+	if (opendmarc_policy_fetch_rua(pctx, NULL, 0, 1) == NULL)
+	{
+		printf("\t%s(%d): fetch_rua(NULL, 0): FAIL\n", __FILE__, __LINE__);
+		fails += 1;
+	}
+
+	count++;
+	(void) opendmarc_policy_fetch_rua(pctx, NULL, 256, 1);
+
+	count++;
+	{
+		u_char buf[256];
+		u_char *ret = opendmarc_policy_fetch_rua(pctx, buf, sizeof buf, 1);
+		if (ret == NULL)
+		{
+			printf("\t%s(%d): fetch_rua with valid buf returned NULL: FAIL\n", __FILE__, __LINE__);
+			fails += 1;
+		}
+	}
+
 	return fails;
 }

--- a/opendmarc/opendmarc-ar.c
+++ b/opendmarc/opendmarc-ar.c
@@ -366,7 +366,7 @@ ares_parse(u_char *hdr, struct authres *ar)
 	int r = 0;
 	int state;
 	int prevstate;
-	u_char tmp[MAXHEADER + 2];
+	u_char tmp[MAXHEADER + 1];
 	u_char *tokens[ARES_MAXTOKENS];
 
 	assert(hdr != NULL);

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -2213,7 +2213,7 @@ mlfi_envfrom(SMFICTX *ctx, char **envfrom)
 
 		p = strchr(dfc->mctx_envfrom, '@');
 		if (p != NULL)
-			strncpy(dfc->mctx_envdomain, p + 1, BUFRSZ);
+			strlcpy(dfc->mctx_envdomain, p + 1, sizeof dfc->mctx_envdomain);
 	}
 
 	return SMFIS_CONTINUE;
@@ -4159,8 +4159,6 @@ static void
 dmarcf_config_free(struct dmarcf_config *conf)
 {
 	assert(conf != NULL);
-	assert(conf->conf_refcnt == 0);
-
 	if (conf->conf_data != NULL)
 		config_free(conf->conf_data);
 

--- a/opendmarc/opendmarc.h
+++ b/opendmarc/opendmarc.h
@@ -36,7 +36,7 @@
 #define	DEFREPORTCMD	"/usr/sbin/sendmail -t -odq"
 #define	JOBIDUNKNOWN	"(unknown-jobid)"
 #define	MAXARGV		65536
-#define	MAXHEADER	1024
+#define	MAXHEADER	4096
 #define	TEMPFILE	"/var/tmp/dmarcXXXXXX"
 
 #define AUTHRESULTSHDR	"Authentication-Results"


### PR DESCRIPTION
## Summary

- **#256** — `opendmarc_policy_fetch_ruf()`: `||` → `&&` in the memset guard, matching the correct `&&` already used in `opendmarc_policy_fetch_rua()`. Prevents `memset(NULL, …)` when called with a NULL buffer and non-zero size. Regression test added to `test_dmarc_fetch.c`.
- **#18** — `dmarcf_config_free()`: remove `assert(conf->conf_refcnt == 0)`, which fires on normal shutdown and config-reload paths that call the function without checking the refcount first.
- **#140** — `mlfi_envfrom()`: replace `strncpy(mctx_envdomain, p+1, BUFRSZ)` with `strlcpy(…, sizeof mctx_envdomain)` to guarantee null-termination when the source fills the buffer.
- **#152** — Bump `MAXHEADER` from 1024 → 4096 in `opendmarc.h`; two `snprintf()` calls building the `Authentication-Results` header can produce ~2080 bytes, causing silent truncation of outgoing headers. Also fixes the `MAXHEADER+2` → `MAXHEADER+1` off-by-one in `opendmarc-ar.c`.

Closes #18, #140, #152, #256. Tracked in #297.

## Test plan
- [ ] `make check` passes (7/7)
- [ ] `test_dmarc_fetch` covers `fetch_ruf` and `fetch_rua` with NULL buf + non-zero size (the #256 crash case) and with a valid buffer