### PR TITLE
Add ::1 to default IgnoreHosts list (issue #286)

### DIFF
--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -4597,6 +4597,7 @@ main(int argc, char **argv)
 	else if (!testmode)
 	{
 		dmarcf_addlist("127.0.0.1", &ignore);
+		dmarcf_addlist("::1", &ignore);
 	}
 
 	if (!gotp && !testmode)

--- a/opendmarc/opendmarc.conf.5.in
+++ b/opendmarc/opendmarc.conf.5.in
@@ -211,7 +211,7 @@ SMTP AUTH) to be ignored by the filter.  The default is "false".
 .I IgnoreHosts (string)
 Specifies the path to a file that contains a list of hostnames, IP addresses,
 and/or CIDR expressions identifying hosts whose SMTP connections are to be
-ignored by the filter.  If not specified, defaults to "127.0.0.1" only.
+ignored by the filter.  If not specified, defaults to "127.0.0.1" and "::1".
 
 .TP
 .I IgnoreMailFrom (string)

--- a/opendmarc/opendmarc.conf.sample
+++ b/opendmarc/opendmarc.conf.sample
@@ -240,7 +240,7 @@
 ##  Specifies the path to a file that contains a list of hostnames, IP
 ##  addresses, and/or CIDR expressions identifying hosts whose SMTP
 ##  connections are to be ignored by the filter.  If not specified, defaults
-##  to "127.0.0.1" only.
+##  to "127.0.0.1" and "::1".
 #
 # IgnoreHosts /usr/local/etc/opendmarc/ignore.hosts
 


### PR DESCRIPTION
Fixes #286.

When no `IgnoreHosts` file is configured, only `127.0.0.1` was added to
the default ignore list. Connections from the IPv6 loopback address `::1`
were not ignored, causing DMARC evaluation to run on localhost-originated
mail.

This adds `::1` alongside `127.0.0.1` as a default, and updates the man
page and sample config to reflect both addresses.