### PR TITLE
Cherry-pick documentation updates from issue #19

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -105,7 +105,7 @@ release, and a summary of the changes in that release.
 	Feature request #127: Log SPF results when rejecting.  Requested
 		by Patrick Wagner; patch from Andreas Schulze, follow-up
 		patch from Juri Haberland.
-	Feature request #138: Inculde policy and disposition information
+	Feature request #138: Include policy and disposition information
 		in an Authentication-Results comment.  Based on a patch
 		from Juri Haberland.
 	Feature request #139: Include the client host name if known

--- a/db/README.schema
+++ b/db/README.schema
@@ -15,6 +15,10 @@ selectors	A table that maps selector names to unique integer IDs.
 		foreign key (into the domains table) for the domain that owns the
 		selector.
 
+arcautchresults	A table for logging ARC-Authentication-Results information.
+
+arcseals	A table for logging ARC-Seal information.
+
 reporters	A table mapping reporting hosts to unique integer IDs.
 		Intended for use by multi-MX systems so it's possible to tell
 		where an inbound message landed.

--- a/opendmarc/opendmarc.8.in
+++ b/opendmarc/opendmarc.8.in
@@ -125,8 +125,8 @@ above).  May be specified more than once to request increasing amounts of
 output.
 .TP
 .I \-V
-Print the version number and supported canonicalization and signature
-algorithms, and then exit without doing anything else.
+Print the version number, whether SPF support is compiled in, and the
+libmilter version, and then exit without doing anything else.
 .SH SIGNALS
 Upon receiving SIGUSR1, if the filter was started with a configuration
 file, it will be re-read and the new values used.  Note that any
@@ -160,8 +160,12 @@ RFC5321 \- Simple Mail Transfer Protocol
 .P
 RFC5322 \- Internet Messages
 .P
-RFC5451 \- Message Header Field for Indicating Message Authentication Status
+RFC5451 \- Message Header Field for Indicating Message Authentication Status (obsoleted by RFC7601)
 .P
 RFC6376 \- DomainKeys Identified Mail
 .P
 RFC6591 \- Authentication Failure Reporting Using the Abuse Reporting Format
+.P
+RFC7489 \- Domain-based Message Authentication, Reporting, and Conformance (DMARC)
+.P
+RFC7601 \- Message Header Field for Indicating Message Authentication Status

--- a/opendmarc/opendmarc.conf.5.in
+++ b/opendmarc/opendmarc.conf.5.in
@@ -15,7 +15,8 @@ specification for message authentication, policy enforcement, and reporting.
 This file is its configuration file.
 
 Blank lines are ignored.  Lines containing a hash ("#") character are
-truncated at the hash character to allow for comments in the file.
+truncated at the hash character to allow for comments in the file.  Lines
+longer than 1024 characters are also truncated.
 
 Other content should be the name of a parameter, followed by white space,
 followed by the value of that parameter, each on a separate line.
@@ -190,6 +191,9 @@ report.  It is expected that this will not be used in its raw form, but
 rather periodically imported into a relational database from which the
 aggregate reports can be extracted using
 .B opendmarc-importstats(8).
+For each record, the file is opened, locked, the data is appended, and the
+file is unlocked.  When the file is renamed on the filesystem, opendmarc
+will create a new file at the original path.
 
 .TP
 .I HoldQuarantinedMessages (Boolean)
@@ -222,8 +226,8 @@ no mail is ignored.
 
 .TP
 .I MilterDebug (integer)
-Sets the debug level to be requested from the milter library.  The
-default is 0.
+Sets the debug level to be requested from the milter library.  Six is the
+highest useful value.  The default is 0.
 
 .TP
 .I PidFile (string)
@@ -267,7 +271,7 @@ Indicates the shell command to which failure reports should be passed for
 delivery when
 .I FailureReports
 is enabled.  Defaults to
-.I /usr/sbin/sendmail.
+.I /usr/sbin/sendmail -t -odq.
 
 .TP
 .I RequiredHeaders (Boolean)
@@ -340,9 +344,14 @@ The default is "mail".
 .I TrustedAuthservIDs (string)
 Provides a list of authserv-ids that are to be used to identify
 Authentication-Results header fields whose contents are to be assumed as valid
-input for the DMARC assessment.  To provide a list, separate values by commas.
-If the string "HOSTNAME" is provided, the name of the host running the filter
-(as returned by the
+input for the DMARC assessment.  If
+.I AuthservIDWithJobID
+is set and the authserv-id of an inspected Authentication-Results header is
+not found in
+.I TrustedAuthservIDs,
+the job ID is appended to the authserv-id before matching.  To provide a
+list, separate values by commas.  If the string "HOSTNAME" is provided, the
+name of the host running the filter (as returned by the
 .I gethostname(3)
 function) will be used.  Matching against this list is case-insensitive.  The
 default is to use the value of
@@ -389,10 +398,14 @@ All rights reserved.
 .P
 RFC4408 \- Sender Policy Framework
 .P
-RFC5451 \- Message Header Field for Indicating Message Authentication Status
+RFC5451 \- Message Header Field for Indicating Message Authentication Status (obsoleted by RFC7601)
 .P
 RFC5965 \- An Extensible Format for Email Feedback Reports
 .P
 RFC6376 \- DomainKeys Identified Mail
 .P
 RFC6591 \- Authentication Failure Reporting Using the Abuse Reporting Format
+.P
+RFC7489 \- Domain-based Message Authentication, Reporting, and Conformance (DMARC)
+.P
+RFC7601 \- Message Header Field for Indicating Message Authentication Status


### PR DESCRIPTION
Closes #19.

Cherry-picked the good bits from the patch set posted in the issue,
skipping the removal of per-field defaults (we want those) and applying
some light cleanup to the prose. Credit to @dilyanpalauzov for the
original patches.

- Fix typo "Inculde" in `RELEASE_NOTES`
- Add ARC table descriptions to `db/README.schema`
- Update `-V` flag description in `opendmarc.8.in`
- RFC references in `opendmarc.8.in` and `opendmarc.conf.5.in`: note RFC5451 obsoleted by RFC7601, add RFC7489 and RFC7601
- Document 1024-character line truncation in `opendmarc.conf.5.in`
- Add `HistoryFile` locking/rename behavior note
- Add `MilterDebug` maximum useful value (6)
- Correct `ReportCommand` default to include `-t -odq`
- Clarify `TrustedAuthservIDs` interaction with `AuthservIDWithJobID`