### PR TITLE
Fix arcdomain memory leak in mlfi_eom (issue #182)

### DIFF
--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -2970,6 +2970,7 @@ mlfi_eom(SMFICTX *ctx)
 							eptr = hsearch(entry,
 							               FIND);
 							pthread_rwlock_unlock(&hash_lock);
+							free(arcdomain);
 							if (eptr == NULL)
 								continue;
 


### PR DESCRIPTION
Fixes #182.

`arcdomain` was `strdup`'d on each iteration of the ARC chain loop but
never freed — it leaked on the `continue` path when the hash lookup
missed, and again at loop exit when it hit. Free it after the
`pthread_rwlock_unlock` call, before the `eptr` NULL check, so it's
released on every iteration regardless of outcome.

Credit to @KIC-8462852 for the original patch.