### PR TITLE
Fix arc=pass never appearing in aggregate reports (issue #282)

### DIFF
--- a/reports/opendmarc-reports.in
+++ b/reports/opendmarc-reports.in
@@ -722,7 +722,7 @@ foreach (@$domainset)
 
 		switch ($arc)
 		{
-			case 1	{ $arcstr = "pass"; }
+			case 0	{ $arcstr = "pass"; }
 			else	{ $arcstr = "fail"; }
 		}
 


### PR DESCRIPTION
Fixes #282.

`ARES_RESULT_PASS` is 0, but the `arc` switch in `opendmarc-reports` used `case 1` (`ARES_RESULT_UNUSED`), so ARC pass was never matched and all messages were reported as `arc=fail` in aggregate reports regardless of actual ARC evaluation.

The `arc_policy` switch was correctly fixed to `case 0` in commit 199b506 but the `arc` switch was missed at the same time.

This started as a suspected doc issue but git blame showed it was a real bug introduced with the original ValiMail ARC contribution and only half-fixed in the follow-up commit.