### PR TITLE
Document missing options in opendmarc-reports man page (issue #292)

### DIFF
--- a/reports/opendmarc-reports.8.in
+++ b/reports/opendmarc-reports.8.in
@@ -97,8 +97,19 @@ The default is 25.
 Instructs the database to change to the UTC timezone when generating output.
 Otherwise, the database default is used.
 .TP
+.I --keepfiles
+Keep the generated XML report files in the local directory rather than
+deleting them after sending.
+.TP
+.I --test (-n)
+Do not send reports.  Implies
+.I --keepfiles
+and
+.I --noupdate.
+.TP
 .I --verbose
-Increase the amount of verbosity written to standard output.
+Increase the amount of verbosity written to standard output.  May be
+repeated for further increased output.
 .TP
 .I --version
 Print version number and exit.


### PR DESCRIPTION
Fixes #292.

`--keepfiles` and `--test` / `-n` were not documented in the man page at all. `--verbose` was missing the note that it can be repeated for increased output.