### PR TITLE
Fix configure.ac not including headers required by resolv.h (issue #257)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -158,14 +158,38 @@ AC_CHECK_LIB(resolv, inet_aton, , , [-lnsl -lsocket])
 # only thing for it is to include resolv.h, don't redeclare res_ninit(),
 # and use the proper type signature when calling it.
 m4_rename([AC_LANG_CALL], [saved_AC_LANG_CALL])
-m4_define([AC_LANG_CALL], [AC_LANG_PROGRAM([#include <resolv.h>],
+m4_define([AC_LANG_CALL], [AC_LANG_PROGRAM([#ifdef HAVE_SYS_TYPES_H
+#  include <sys/types.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+#  include <netinet/in.h>
+#endif
+#ifdef HAVE_ARPA_NAMESER_H
+#  include <arpa/nameser.h>
+#endif
+#ifdef HAVE_NETDB_H
+#  include <netdb.h>
+#endif
+#include <resolv.h>],
                                            [return res_ninit(NULL);])])
 AC_SEARCH_LIBS(res_ninit, resolv,
         AC_DEFINE(HAVE_RES_NINIT, 1,
         [Define to 1 if you have the `res_ninit()' function.]))
 
 # Same as above, but for res_ndestroy.
-m4_define([AC_LANG_CALL], [AC_LANG_PROGRAM([#include <resolv.h>],
+m4_define([AC_LANG_CALL], [AC_LANG_PROGRAM([#ifdef HAVE_SYS_TYPES_H
+#  include <sys/types.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+#  include <netinet/in.h>
+#endif
+#ifdef HAVE_ARPA_NAMESER_H
+#  include <arpa/nameser.h>
+#endif
+#ifdef HAVE_NETDB_H
+#  include <netdb.h>
+#endif
+#include <resolv.h>],
                                             [res_ndestroy(NULL);])])
 AC_SEARCH_LIBS(res_ndestroy, resolv,
         AC_DEFINE(HAVE_RES_NDESTROY, 1,


### PR DESCRIPTION
## Summary

The `res_ninit` and `res_ndestroy` detection blocks in `configure.ac` included `resolv.h` directly, without first including the prerequisite headers identified by `AC_HEADER_RESOLV`. On non-glibc platforms where `resolv.h` requires `sys/types.h`, `netinet/in.h`, `arpa/nameser.h`, or `netdb.h`, the checks would silently fail to detect the functions even when present.

This fix adds the standard conditional include block before `resolv.h` in both detection blocks, consistent with what `AC_HEADER_RESOLV` is designed to ensure.

Credit to @futatuki for the diagnosis and original fix (f946ec9), and to @Adadov for an independently verified implementation (c52b7d7).

Fixes #257.

## Test plan

- [ ] Confirm `./configure` correctly detects `res_ninit`/`res_ndestroy` on a non-glibc platform (e.g. musl or older FreeBSD)
- [ ] Confirm no regression on glibc (Linux) — detection should still work as before