### PR TITLE
Fix SIGHUP: reload config instead of shutting down

### DIFF
--- a/opendmarc/opendmarc.8.in
+++ b/opendmarc/opendmarc.8.in
@@ -128,7 +128,11 @@ output.
 Print the version number and supported canonicalization and signature
 algorithms, and then exit without doing anything else.
 .SH SIGNALS
-Upon receiving SIGUSR1, if the filter was started with a configuration
+Upon receiving
+.B SIGHUP
+or
+.BR SIGUSR1 ,
+if the filter was started with a configuration
 file, it will be re-read and the new values used.  Note that any
 command line overrides provided at startup time will be lost when this is
 done.  Also, the following configuration file values (and their corresponding

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -3966,12 +3966,12 @@ struct smfiDesc smfilter =
 static void
 dmarcf_sighandler(int sig)
 {
-	if (sig == SIGINT || sig == SIGTERM || sig == SIGHUP)
+	if (sig == SIGINT || sig == SIGTERM)
 	{
 		diesig = sig;
 		die = TRUE;
 	}
-	else if (sig == SIGUSR1)
+	else if (sig == SIGHUP || sig == SIGUSR1)
 	{
 		if (conffile != NULL)
 			reload = TRUE;


### PR DESCRIPTION
Closes #322.

`SIGHUP` was grouped with `SIGTERM` and `SIGINT` in the signal handler,
causing the filter to shut down — contrary to Unix convention, where
`SIGHUP` is the standard signal for configuration reload or log reopen.

The reload path already existed (previously reachable only via `SIGUSR1`);
this change folds `SIGHUP` into the same condition.

`SIGTERM` and `SIGINT` remain the shutdown signals. `SIGUSR1` continues
to work as before.

Changes:
- `opendmarc/opendmarc.c`: remove `SIGHUP` from the shutdown condition;
  add it to the reload condition alongside `SIGUSR1`
- `opendmarc/opendmarc.8.in`: document that both `SIGHUP` and `SIGUSR1`
  trigger a configuration reload