### PR TITLE
Fix SPF regression from #262: set env_from before helo_dom

### DIFF
--- a/libopendmarc/opendmarc_spf.c
+++ b/libopendmarc/opendmarc_spf.c
@@ -164,14 +164,25 @@ opendmarc_spf2_test(char *ip_address, char *mail_from_domain, char *helo_domain,
 	}
 
 	ret = opendmarc_spf2_find_mailfrom_domain(ctx, mail_from_domain, mfrom, sizeof mfrom, used_mfrom);
-	if (ret != 0 || *used_mfrom == FALSE)
+	if (ret == 0 && *used_mfrom == TRUE)
+	{
+		/*
+		 * Set env_from before helo_dom: some libspf2 versions use the
+		 * first-set domain as the check domain, so env_from must be
+		 * established first. helo_dom is then available for %{h} macro
+		 * expansion without redirecting the check to the HELO hostname.
+		 */
+		SPF_request_set_env_from(ctx->spf_request, mfrom);
+		if (helo_domain != NULL)
+		{
+			(void) strlcpy(helo, helo_domain, sizeof helo);
+			SPF_request_set_helo_dom(ctx->spf_request, helo);
+		}
+	}
+	else if (helo_domain != NULL)
 	{
 		(void) strlcpy(helo, helo_domain, sizeof helo);
 		SPF_request_set_helo_dom(ctx->spf_request, helo);
-	}
-	else
-	{
-		SPF_request_set_env_from(ctx->spf_request, mfrom);
 	}
 	ctx->spf_response = NULL;
 	SPF_request_query_mailfrom(ctx->spf_request, &(ctx->spf_response));


### PR DESCRIPTION
## Summary

Fixes a regression introduced in the v1 fix on the `fix/issue-262-spf-helo-macro` branch, reported by @andreasschulze in issue #262.

**Root cause**: the previous fix called `SPF_request_set_helo_dom()` unconditionally before `SPF_request_set_env_from()`. Some libspf2 versions treat the first-set domain as the check domain. This caused SPF to check the HELO hostname (e.g. `mx0.taxi-dortmund.de`) instead of the mailfrom domain (`taxi-dortmund.de`). For HELO hostnames with no SPF record this produced `spf=none` instead of `spf=pass` (regression reported by @andreasschulze).

**Fix**: when mailfrom is found, set `env_from` first to anchor the check domain, then set `helo_dom` so `%{h}` macro expansion works. When mailfrom is not found, set only `helo_dom` (unchanged from the original fallback behavior).

## Behavior

| Scenario | Before v1 fix | After v1 fix | After this fix |
|---|---|---|---|
| mailfrom found, SPF record present | `pass` | `none` (regression) | `pass` |
| mailfrom found, SPF uses `%{h}` macro | `permerror` (original bug) | `pass` | `pass` |
| mailfrom not found, HELO fallback | unchanged | unchanged | unchanged |

## Test plan

- [ ] Confirm `spf=pass` for a standard mailfrom domain with an SPF record (@andreasschulze's `taxi-dortmund.de` case)
- [ ] Confirm `spf=pass` for a domain using `%{h}` macro in its SPF record (original issue #262 case)
- [ ] Confirm HELO fallback still works when MAIL FROM is empty