### PR TITLE
ares_parse: handle ADMD-less Authentication-Results headers

### DIFF
--- a/opendmarc/opendmarc-ar.c
+++ b/opendmarc/opendmarc-ar.c
@@ -434,6 +434,23 @@ ares_parse(u_char *hdr, struct authres *ar)
 				prevstate = state;
 				state = 2;
 			}
+			else if (tokens[c][0] == '=' && tokens[c][1] == '\0')
+			{
+				/*
+				 * ADMD-less header (e.g. Office 365 internal
+				 * headers that escape outbound): the token we
+				 * read as authserv-id is actually the first
+				 * method name.  Leave ares_host empty and
+				 * continue parsing from the result value.
+				 */
+				n = 1;
+				ar->ares_result[0].result_method =
+					ares_convert(methods,
+					             (char *) ar->ares_host);
+				memset(ar->ares_host, '\0', sizeof ar->ares_host);
+				prevstate = state;
+				state = 5;
+			}
 			else
 			{
 				return -1;


### PR DESCRIPTION
## Summary

Office 365 generates `Authentication-Results` headers that omit the authserv-id (ADMD), jumping straight to `method=result` tokens:

```
Authentication-Results: spf=pass smtp.mailfrom=example.com
Authentication-Results: compauth=pass reason=000
```

RFC 8601 requires the authserv-id before the semicolon, so these are technically non-compliant. However they are common enough in practice that the current hard parse failure has real consequences: log noise on every O365-originated message, and OpenDMARC interpreting the unparsed header as an authentication failure for otherwise valid mail.

## Fix

In state 1 of `ares_parse()`, when `=` is seen instead of `;` or a version digit, the token we read as authserv-id is actually the first method name. The fix recovers gracefully: `ares_host` is left empty (signalling no authserv-id present), the token is slotted as the method, and parsing continues from the result value.

The same fix has been applied to OpenDKIM (see trusteddomainproject/OpenDKIM#372).

## Test plan

- [ ] `Authentication-Results: spf=pass smtp.mailfrom=example.com` parses without error, `ares_host` is empty, method is `spf`, result is `pass`
- [ ] `Authentication-Results: compauth=pass reason=000` parses without error, method is `unknown`
- [ ] Standard RFC-compliant headers with authserv-id are unaffected