### PR TITLE
ci: add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+  workflow_dispatch:
+
+jobs:
+  build-test-linux:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y \
+            autoconf automake libtool pkg-config \
+            libssl-dev libmilter-dev \
+            lua5.4 liblua5.4-dev
+
+      - name: Build miltertest from OpenDKIM
+        run: |
+          git clone --depth=1 https://github.com/trusteddomainproject/OpenDKIM.git /tmp/opendkim
+          cd /tmp/opendkim
+          autoreconf -fvi
+          ./configure --enable-lua CFLAGS='-g -O2 -Wno-pointer-sign'
+          make -j$(nproc)
+          sudo make -C miltertest install
+
+      - name: Bootstrap build system
+        run: autoreconf -fvi
+
+      - name: Configure
+        run: |
+          ./configure --enable-live-tests \
+            CFLAGS='-g -O2 -Wno-pointer-sign'
+
+      - name: Build
+        run: make -j$(nproc)
+
+      - name: Test
+        run: make check


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` mirroring the CI setup in OpenDKIM
- Runs on push/PR to `develop`, plus manual `workflow_dispatch`
- Builds miltertest from the OpenDKIM repo as a pre-step (miltertest is not packaged separately), then configures OpenDMARC with `--enable-live-tests` to run the existing miltertest-based test suite
- Uses `-Wno-pointer-sign` to suppress the known pointer-sign noise across the codebase (tracked separately in #361)

## Test plan

- [ ] CI run passes on this PR
- [ ] All miltertest-based tests (`t-verify-*`) pass