### PR TITLE
ci: build miltertest from standalone repo instead of OpenDKIM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,14 @@ jobs:
             libssl-dev libmilter-dev \
             lua5.4 liblua5.4-dev
 
-      - name: Build miltertest from OpenDKIM
+      - name: Build miltertest
         run: |
-          git clone --depth=1 https://github.com/trusteddomainproject/OpenDKIM.git /tmp/opendkim
-          cd /tmp/opendkim
+          git clone --depth=1 https://github.com/thegushi/miltertest.git /tmp/miltertest
+          cd /tmp/miltertest
           autoreconf -fvi
-          ./configure --enable-lua CFLAGS='-g -O2 -Wno-pointer-sign'
+          ./configure CFLAGS='-g -O2 -Wno-pointer-sign'
           make -j$(nproc)
-          sudo make -C miltertest install
+          sudo make install
 
       - name: Bootstrap build system
         run: autoreconf -fvi


### PR DESCRIPTION
## Summary

- Fixes CI failure caused by OpenDKIM's configure failing to find `SSL_library_init` under OpenSSL 3 on Ubuntu
- Switches to building miltertest from the standalone https://github.com/thegushi/miltertest repo, which only requires libmilter and Lua - no OpenSSL dependency
- Cleaner separation: miltertest is no longer tightly coupled to OpenDKIM's build system

## Root cause

The previous step cloned and built full OpenDKIM to get miltertest. OpenDKIM's configure checks for `SSL_library_init` which is not a linkable symbol in OpenSSL 3, causing configure to abort.