### PR TITLE
Include RFC5322 error reason in SMTP rejection response (issue #202)

### DIFF
--- a/opendmarc/Makefile.am
+++ b/opendmarc/Makefile.am
@@ -16,6 +16,7 @@ opendmarc_SOURCES = config.c config.h opendmarc.c opendmarc.h \
 	opendmarc-arcseal.c opendmarc-arcseal.h \
 	opendmarc-config.h \
 	opendmarc-dstring.c opendmarc-dstring.h \
+	opendmarc-spf-parse.c opendmarc-spf-parse.h \
 	parse.c parse.h test.c test.h util.c util.h
 opendmarc_CC = $(PTHREAD_CC)
 opendmarc_CFLAGS = $(PTHREAD_CFLAGS)

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -2277,6 +2277,8 @@ mlfi_eom(SMFICTX *ctx)
 			       dfc->mctx_jobid, reqhdrs_error);
 		}
 
+		dmarcf_setreply(ctx, DMARC_REJECT_SMTP, DMARC_REJECT_ESC,
+		                reqhdrs_error);
 		return SMFIS_REJECT;
 	}
 


### PR DESCRIPTION
## Summary

When `RequiredHeaders` rejects a message, the rejection reason was logged to syslog but the SMTP response was a generic `550 5.7.1` with no detail. This calls `dmarcf_setreply()` with the specific error string so the sending client sees a meaningful message (e.g. `not exactly one Date field`) rather than a Postfix-generated default.

Fixes #202.

## Test plan

- [ ] Send a message missing a required header (e.g. no `Date:`) and confirm the SMTP rejection response includes the specific reason string