### PR TITLE
Add opendmarc-spf-parse.c to Makefile.am (issue #334)

### DIFF
--- a/opendmarc/Makefile.am
+++ b/opendmarc/Makefile.am
@@ -16,6 +16,7 @@ opendmarc_SOURCES = config.c config.h opendmarc.c opendmarc.h \
 	opendmarc-arcseal.c opendmarc-arcseal.h \
 	opendmarc-config.h \
 	opendmarc-dstring.c opendmarc-dstring.h \
+	opendmarc-spf-parse.c opendmarc-spf-parse.h \
 	parse.c parse.h test.c test.h util.c util.h
 opendmarc_CC = $(PTHREAD_CC)
 opendmarc_CFLAGS = $(PTHREAD_CFLAGS)


### PR DESCRIPTION
`opendmarc-spf-parse.c` was added in PR #298 but omitted from `opendmarc_SOURCES` in `opendmarc/Makefile.am`, causing a link failure on clean builds:

```
ld: error: undefined reference to `dmarcf_parse_received_spf'
```

Fixes #334.