### PR TITLE
Add --db-dsn option to opendmarc-reports and opendmarc-import (issue #284)

### DIFF
--- a/contrib/opendmarc-run
+++ b/contrib/opendmarc-run
@@ -22,6 +22,12 @@ DBPASSWD=opendmarc
 DBSCHEME=mysql
 WORKDIR=/var/db/opendmarc
 
+# Set DBDSN to a full DBI DSN to override the individual DB connection options
+# above (useful for SSL, PostgreSQL, or other non-default configurations).
+# Example: DBDSN="DBI:mysql:database=opendmarc;host=db.example.com;mysql_ssl=1"
+# --dbuser and --dbpasswd are still passed separately when set.
+DBDSN=
+
 # Set DOMAIN to restrict reporting to a single domain, or leave empty to
 # report for all domains with data in the database.
 DOMAIN=
@@ -36,7 +42,11 @@ DOMAIN=
 # survives package upgrades since it is not managed by the package.
 [ -f /etc/opendmarc/opendmarc-run.conf ] && . /etc/opendmarc/opendmarc-run.conf
 
-DBOPTS="--dbhost=${DBHOST} --dbuser=${DBUSER} --dbpasswd=${DBPASSWD} --dbscheme=${DBSCHEME}"
+if [ -n "${DBDSN}" ]; then
+	DBOPTS="--db-dsn=${DBDSN} --dbuser=${DBUSER} --dbpasswd=${DBPASSWD}"
+else
+	DBOPTS="--dbhost=${DBHOST} --dbuser=${DBUSER} --dbpasswd=${DBPASSWD} --dbscheme=${DBSCHEME}"
+fi
 
 # Rotate the history file atomically before importing so that opendmarc
 # can immediately start writing new records while we process the old ones.

--- a/reports/opendmarc-import.in
+++ b/reports/opendmarc-import.in
@@ -40,6 +40,7 @@ my $dbname;
 my $dbuser;
 my $dbpasswd;
 my $dbport;
+my $db_dsn;
 my $inputfile;
 my $inputfh;
 
@@ -436,6 +437,7 @@ sub update_db
 sub usage
 {
 	print STDERR "$progname: usage: $progname [options]\n";
+	print STDERR "\t--db-dsn=dsn       full DBI DSN (overrides --dbscheme/--dbhost/--dbname/--dbport)\n";
 	print STDERR "\t--dbscheme=scheme  mysql or MariaDB [$def_dbscheme]\n";
 	print STDERR "\t--dbhost=host      database host [$def_dbhost]\n";
 	print STDERR "\t--dbname=name      database name [$def_dbname]\n";
@@ -449,7 +451,8 @@ sub usage
 }
 
 # parse command line arguments
-my $opt_retval = &Getopt::Long::GetOptions ('dbscheme=s' => \$dbscheme,
+my $opt_retval = &Getopt::Long::GetOptions ('db-dsn=s' => \$db_dsn,
+                                            'dbscheme=s' => \$dbscheme,
                                             'dbhost=s' => \$dbhost,
                                             'dbname=s' => \$dbname,
                                             'dbpasswd=s' => \$dbpasswd,
@@ -565,12 +568,19 @@ if (!flock($inputfh, LOCK_SH))
 	print STDERR "$progname: warning: unable to establish read lock\n";
 }
 
-require "DBD/$dbscheme.pm";
-
-my $dbi_dsn = "DBI:" . $dbscheme . ":database=" . $dbname .
-    ";host=" . $dbhost;
-if ($dbport != $def_dbport) {
-    $dbi_dsn .= ";port=" . $dbport;
+my $dbi_dsn;
+if (defined($db_dsn))
+{
+	$dbi_dsn = $db_dsn;
+}
+else
+{
+	require "DBD/$dbscheme.pm";
+	$dbi_dsn = "DBI:" . $dbscheme . ":database=" . $dbname .
+	    ";host=" . $dbhost;
+	if ($dbport != $def_dbport) {
+	    $dbi_dsn .= ";port=" . $dbport;
+	}
 }
 
 $dbi_h = DBI->connect($dbi_dsn, $dbuser, $dbpasswd, { PrintError => 0 });

--- a/reports/opendmarc-reports.in
+++ b/reports/opendmarc-reports.in
@@ -147,6 +147,7 @@ my $dbname;
 my $dbuser;
 my $dbpasswd;
 my $dbport;
+my $db_dsn;
 
 my $dbscheme     = $def_dbscheme;
 
@@ -245,6 +246,7 @@ sub usage
 {
 	print STDERR "$progname: usage: $progname [options]\n";
 	print STDERR "\t--day              send yesterday's data\n";
+	print STDERR "\t--db-dsn=dsn       full DBI DSN (overrides --dbscheme/--dbhost/--dbname/--dbport)\n";
 	print STDERR "\t--dbscheme=scheme  mysql or MariaDB [$def_dbscheme]\n";
 	print STDERR "\t--dbhost=host      database host [$def_dbhost]\n";
 	print STDERR "\t--dbname=name      database name [$def_dbname]\n";
@@ -350,6 +352,7 @@ setlocale(LC_ALL, 'C');
 
 # parse command line arguments
 my $opt_retval = &Getopt::Long::GetOptions ('day!' => \$daybound,
+                                            'db-dsn=s' => \$db_dsn,
                                             'dbscheme=s' => \$dbscheme,
                                             'dbhost=s' => \$dbhost,
                                             'dbname=s' => \$dbname,
@@ -637,12 +640,19 @@ if ($forensic)
 	exit($smtpfail ? 1 : 0);
 }
 
-require "DBD/$dbscheme.pm";
-
-my $dbi_dsn = "DBI:" . $dbscheme . ":database=" . $dbname .
-              ";host=" . $dbhost;
-if ($dbport != $def_dbport) {
-    $dbi_dsn .= ";port=" . $dbport;
+my $dbi_dsn;
+if (defined($db_dsn))
+{
+	$dbi_dsn = $db_dsn;
+}
+else
+{
+	require "DBD/$dbscheme.pm";
+	$dbi_dsn = "DBI:" . $dbscheme . ":database=" . $dbname .
+	           ";host=" . $dbhost;
+	if ($dbport != $def_dbport) {
+	    $dbi_dsn .= ";port=" . $dbport;
+	}
 }
 
 $dbi_h = DBI->connect($dbi_dsn, $dbuser, $dbpasswd, { PrintError => 0 });


### PR DESCRIPTION
Adds a `--db-dsn` option to `opendmarc-reports` and `opendmarc-import` that accepts a full DBI DSN, bypassing the script's built-in DSN construction from `--dbhost`/`--dbname`/`--dbscheme`/`--dbport`. `--dbuser` and `--dbpasswd` continue to work alongside it.

This allows operators to pass engine-specific parameters (SSL flags, socket paths, PostgreSQL options, etc.) that the scripts otherwise have no way to express. For example:

```
--db-dsn="DBI:mysql:database=opendmarc;host=db.example.com;mysql_ssl=1;mysql_ssl_ca_file=/etc/ssl/ca.pem"
```

`opendmarc-run` gains a `DBDSN` variable (empty by default) that, when set, passes `--db-dsn` instead of the individual connection flags. Users set it in `/etc/opendmarc/opendmarc-run.conf`.

Closes #284.