### PR TITLE
configure.ac: include resolv.h prerequisite headers for res_ninit/res_ndestroy (issue #257)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -158,15 +158,42 @@ AC_CHECK_LIB(resolv, inet_aton, , , [-lnsl -lsocket])
 # it, it conflicts with AC_LANG_CALL's redeclaration. Hmm. I guess the
 # only thing for it is to include resolv.h, don't redeclare res_ninit(),
 # and use the proper type signature when calling it.
+# Before using resolv.h, check for headers it may require on non-glibc
+# platforms (BSD, musl, etc.).
+AC_HEADER_RESOLV
 m4_rename([AC_LANG_CALL], [saved_AC_LANG_CALL])
-m4_define([AC_LANG_CALL], [AC_LANG_PROGRAM([#include <resolv.h>],
+m4_define([AC_LANG_CALL], [AC_LANG_PROGRAM([#ifdef HAVE_SYS_TYPES_H
+#  include <sys/types.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+#  include <netinet/in.h>
+#endif
+#ifdef HAVE_ARPA_NAMESER_H
+#  include <arpa/nameser.h>
+#endif
+#ifdef HAVE_NETDB_H
+#  include <netdb.h>
+#endif
+#include <resolv.h>],
                                            [return res_ninit(NULL);])])
 AC_SEARCH_LIBS(res_ninit, resolv,
         AC_DEFINE(HAVE_RES_NINIT, 1,
         [Define to 1 if you have the `res_ninit()' function.]))
 
 # Same as above, but for res_ndestroy.
-m4_define([AC_LANG_CALL], [AC_LANG_PROGRAM([#include <resolv.h>],
+m4_define([AC_LANG_CALL], [AC_LANG_PROGRAM([#ifdef HAVE_SYS_TYPES_H
+#  include <sys/types.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+#  include <netinet/in.h>
+#endif
+#ifdef HAVE_ARPA_NAMESER_H
+#  include <arpa/nameser.h>
+#endif
+#ifdef HAVE_NETDB_H
+#  include <netdb.h>
+#endif
+#include <resolv.h>],
                                             [res_ndestroy(NULL);])])
 AC_SEARCH_LIBS(res_ndestroy, resolv,
         AC_DEFINE(HAVE_RES_NDESTROY, 1,


### PR DESCRIPTION
On platforms where `resolv.h` requires additional headers before inclusion (older FreeBSD, NetBSD, musl/Alpine), the `res_ninit` and `res_ndestroy` configure checks fail despite the functions being available, because the test program only included `<resolv.h>` bare.

Adds `AC_HEADER_RESOLV` and wraps both checks with the standard prerequisite guards (`sys/types.h`, `netinet/in.h`, `arpa/nameser.h`, `netdb.h`), matching the pattern already used in OpenDKIM.

Note: modern FreeBSD (13.2/14.1+) fixed their `resolv.h` upstream so this no longer affects current releases, but it remains relevant for other BSDs and musl-based builds.

Closes #257.