### PR TITLE
Log runtime duration in opendmarc-expire and opendmarc-reports (issue #280)

### DIFF
--- a/reports/opendmarc-expire.in
+++ b/reports/opendmarc-expire.in
@@ -53,6 +53,8 @@ my $def_maxage    = 180;
 my $rows;
 my $maxage;
 
+my $now = time();
+
 ###
 ### NO user-serviceable parts beyond this point
 ###
@@ -193,7 +195,7 @@ if ($maxage <= 0)
 
 if ($verbose)
 {
-	print STDERR "$progname: started at " . localtime() . "\n";
+	print STDERR "$progname: started at " . localtime($now) . "\n";
 }
 
 require "DBD/$dbscheme.pm";
@@ -570,7 +572,7 @@ if ($alltables)
 
 if ($verbose)
 {
-	print STDERR "$progname: terminating at " . localtime() . "\n";
+	print STDERR "$progname: terminating at " . localtime() . " (duration=" . scalar(time() - $now) . "s)\n";
 }
 
 $dbi_h->disconnect;

--- a/reports/opendmarc-reports.in
+++ b/reports/opendmarc-reports.in
@@ -1581,7 +1581,7 @@ $dbi_s->finish;
 
 if ($verbose)
 {
-	print STDERR "$progname: terminating at " . localtime() . "\n";
+	print STDERR "$progname: terminating at " . localtime() . " (duration=" . scalar(time() - $now) . "s)\n";
 }
 
 $dbi_h->disconnect;


### PR DESCRIPTION
When `--verbose` is set, the terminating message now includes the total runtime in seconds, e.g.:

```
opendmarc-expire: terminating at Tue May 27 12:34:56 2026 (duration=42s)
```

Applied to both `opendmarc-expire` and `opendmarc-reports`. Also fixes `opendmarc-expire` to capture `$now` at startup so the "started at" timestamp is consistent with the duration calculation.

Credit to @andreasschulze for the original patch in PR #280.

Closes #280.