### PR TITLE
RequiredHeaders: distinguish missing vs multiple From/Date fields (issue #205)

### DIFF
--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -2238,13 +2238,15 @@ mlfi_eom(SMFICTX *ctx)
 	from = dmarcf_findheader(dfc, "From", 0);
 
 	/* verify RFC5322-required headers (RFC5322 3.6) */
-	if (from == NULL ||
-	    dmarcf_findheader(dfc, "From", 1) != NULL)
-		reqhdrs_error = "not exactly one From field";
+	if (from == NULL)
+		reqhdrs_error = "missing From field";
+	else if (dmarcf_findheader(dfc, "From", 1) != NULL)
+		reqhdrs_error = "multiple From fields";
 
-	if (dmarcf_findheader(dfc, "Date", 0) == NULL ||
-	    dmarcf_findheader(dfc, "Date", 1) != NULL)
-		reqhdrs_error = "not exactly one Date field";
+	if (dmarcf_findheader(dfc, "Date", 0) == NULL)
+		reqhdrs_error = "missing Date field";
+	else if (dmarcf_findheader(dfc, "Date", 1) != NULL)
+		reqhdrs_error = "multiple Date fields";
 
 	if (dmarcf_findheader(dfc, "Reply-To", 1) != NULL)
 		reqhdrs_error = "multiple Reply-To fields";


### PR DESCRIPTION
When `RequiredHeaders` was enabled, both a missing From/Date header and multiple From/Date headers produced the same generic error message ("not exactly one From field"), making it difficult to diagnose the actual problem from logs or SMTP rejection text.

Splits each condition so the message is specific:

- `missing From field` / `multiple From fields`
- `missing Date field` / `multiple Date fields`

This matches what OpenDKIM already does. Since PR #333 wires the error reason into the SMTP `550` response, senders now see the specific reason in their bounce.

Closes #205.