### PR TITLE
parse.c: return error on unbalanced '>' in mail address parse (PR #113)

### DIFF
--- a/opendmarc/parse.c
+++ b/opendmarc/parse.c
@@ -454,6 +454,11 @@ dmarcf_mail_parse(unsigned char *line, unsigned char **user_out,
 					*domain_out = w;
 					ws = 0;
 				}
+				else if (type == '>')
+				{
+					err = MAILPARSE_ERR_SUNBALANCED;
+					return err;
+				}
 				else
 				{
 


### PR DESCRIPTION
PR #113 contained this fix mixed in with a large set of changes reverting GitHub references back to SourceForge (wrong direction) and a double-`http://` bug introduced in the spec file. Those changes were not taken; this is the useful portion extracted cleanly.

When `dmarcf_mail_parse()` encounters a bare `>` while parsing the domain portion of an address (e.g. a malformed `From:` with unbalanced angle brackets), it fell through to the generic token handler rather than returning an error. This could cause unexpected behavior downstream. Now returns `MAILPARSE_ERR_SUNBALANCED` consistently with how the rest of the parser handles unbalanced bracket conditions.

The ARC crash fixes from the same PR were already addressed in #298.

Credit to the original author of PR #113.