### PR TITLE
Add RequiredFrom config option

### DIFF
--- a/CHANGES-develop.md
+++ b/CHANGES-develop.md
@@ -83,6 +83,12 @@ CREATE TABLE IF NOT EXISTS suppressions (
 
 ---
 
+## Configuration options
+
+- **`RequiredFrom` option added**: New boolean option that rejects messages lacking a From: field from which a domain can be extracted. Unlike `RequiredHeaders` (which enforces all RFC5322 header count restrictions), `RequiredFrom` enforces only the From field check, making it suitable for deployments where full RFC5322 compliance would reject too many legitimate messages. Prevents attackers from omitting the From header to evade DMARC evaluation. (#147)
+
+---
+
 ## Authentication-Results parsing
 
 - **`Authentication-Results` header authserv-id quoting**: When `AuthservIDWithJobID` was enabled, the job ID was appended without quoting, producing an invalid header when the composite value contained characters requiring quoting. (#311, issue #17)

--- a/opendmarc/opendmarc-config.h
+++ b/opendmarc/opendmarc-config.h
@@ -45,6 +45,7 @@ struct configdef dmarcf_config[] =
 	{ "PublicSuffixList",		CONFIG_TYPE_STRING,	FALSE },
 	{ "RecordAllMessages",		CONFIG_TYPE_BOOLEAN,	FALSE },
 	{ "RequiredHeaders",		CONFIG_TYPE_BOOLEAN,	FALSE },
+	{ "RequiredFrom",		CONFIG_TYPE_BOOLEAN,	FALSE },
 	{ "RejectFailures",		CONFIG_TYPE_BOOLEAN,	FALSE },
 	{ "RejectMultiValueFrom",	CONFIG_TYPE_BOOLEAN,	FALSE },
 	{ "ReportCommand",		CONFIG_TYPE_STRING,	FALSE },

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -166,6 +166,7 @@ typedef struct dmarcf_connctx * DMARCF_CONNCTX;
 struct dmarcf_config
 {
 	_Bool			conf_reqhdrs;
+	_Bool			conf_reqfrom;
 	_Bool			conf_afrf;
 	_Bool			conf_afrfnone;
 	_Bool			conf_rejectfail;
@@ -1242,6 +1243,10 @@ dmarcf_config_load(struct config *data, struct dmarcf_config *conf,
 		                  &conf->conf_reqhdrs,
 		                  sizeof conf->conf_reqhdrs);
 
+		(void) config_get(data, "RequiredFrom",
+		                  &conf->conf_reqfrom,
+		                  sizeof conf->conf_reqfrom);
+
 		(void) config_get(data, "FailureReports",
 		                  &conf->conf_afrf,
 		                  sizeof conf->conf_afrf);
@@ -2290,11 +2295,15 @@ mlfi_eom(SMFICTX *ctx)
 		if (conf->conf_dolog)
 		{
 			syslog(LOG_INFO,
-			       "%s: RFC5322 requirement error: missing From field; accepting",
-			       dfc->mctx_jobid);
+			       "%s: RFC5322 requirement error: missing From field; %s",
+			       dfc->mctx_jobid,
+			       conf->conf_reqfrom ? "reject" : "accepting");
 		}
 
-		return SMFIS_ACCEPT;
+		if (conf->conf_reqfrom)
+			return SMFIS_REJECT;
+		else
+			return SMFIS_ACCEPT;
 	}
 
 	/* extract From: addresses */
@@ -2338,7 +2347,7 @@ mlfi_eom(SMFICTX *ctx)
 			       dfc->mctx_jobid);
 		}
 
-		if (conf->conf_reqhdrs)
+		if (conf->conf_reqhdrs || conf->conf_reqfrom)
 			return SMFIS_REJECT;
 		else
 			return SMFIS_ACCEPT;

--- a/opendmarc/opendmarc.conf.5.in
+++ b/opendmarc/opendmarc.conf.5.in
@@ -281,6 +281,14 @@ failing this test are rejected without further processing.  A From:
 field from which no domain name could be extracted will also be rejected.
 
 .TP
+.I RequiredFrom (Boolean)
+If set, the filter will reject without further processing messages that lack a
+From: field from which a domain name could be extracted.  This option is
+without effect if
+.I RequiredHeaders
+is set to "true".
+
+.TP
 .I Socket (string)
 Specifies the socket that should be established by the filter to receive
 connections from

--- a/opendmarc/opendmarc.conf.sample
+++ b/opendmarc/opendmarc.conf.sample
@@ -330,6 +330,15 @@
 #
 # RequiredHeaders false
 
+##  RequiredFrom { true | false }
+##  	default "false"
+##
+##  If set, the filter will reject without further processing messages that
+##  lack a From: field from which a domain name could be extracted.  This
+##  option is without effect if RequiredHeaders is set to "true".
+#
+# RequiredFrom false
+
 ##  Socket socketspec
 ##  	default (none)
 ##


### PR DESCRIPTION
Implements the feature from PR #147 (originally opened 2021-03-29).

## Summary

Adds a `RequiredFrom` boolean configuration option that rejects messages
lacking a `From:` field from which a valid domain can be extracted.

This is a narrower alternative to `RequiredHeaders`:

- `RequiredHeaders` enforces all RFC5322 header count restrictions and
  is too aggressive for many deployments
- `RequiredFrom` enforces only the From field, which is the check most
  relevant to DMARC - a missing or unparseable From header means there
  is nothing for DMARC to evaluate, and omitting it is a known technique
  for evading the filter

Changes:
- `opendmarc-config.h`: register `RequiredFrom` as a boolean config key
- `opendmarc.c`: add `conf_reqfrom` field; reject at both the missing-From
  and bad-domain-extraction paths when set
- `opendmarc.conf.5.in`: man page entry
- `opendmarc.conf.sample`: commented sample entry
- `CHANGES-develop.md`: documented

Closes #147.

## Test plan

- [ ] Build with `autoreconf -fis && ./configure && make`
- [ ] Start opendmarc with `RequiredFrom true` and send a message with no From header; confirm 5xx rejection
- [ ] Send a message with a malformed From header (no extractable domain); confirm rejection
- [ ] Send normal mail; confirm pass-through
- [ ] Confirm `RequiredHeaders true` still covers the same cases independently