### PR TITLE
opendmarc_util_cleanup: fix off-by-one in buffer length guard

### DIFF
--- a/libopendmarc/opendmarc_util.c
+++ b/libopendmarc/opendmarc_util.c
@@ -160,7 +160,7 @@ opendmarc_util_cleanup(u_char *str, u_char *buf, size_t buflen)
 {
 	char *sp, *ep;
 
-	if (str == NULL || buf == NULL || strlen((char *)str) > buflen)
+	if (str == NULL || buf == NULL || strlen((char *)str) >= buflen)
 	{
 		errno = EINVAL;
 		return NULL;


### PR DESCRIPTION
Fixes the bug reported in PR #188.

`opendmarc_util_cleanup` copies `str` into `buf` of size `buflen`. The
original guard used `> buflen`, allowing a string of exactly `buflen`
characters through. After the `memset` and copy, the buffer would be
full with no room for the null terminator, producing a non-terminated
string.

Changed `>` to `>=` so strings of length `buflen` or longer are
rejected with `EINVAL`.

Closes #188.