### PR TITLE
opendmarc_util_finddomain: handle quoted-pair in double-quoted strings

### DIFF
--- a/libopendmarc/opendmarc_util.c
+++ b/libopendmarc/opendmarc_util.c
@@ -204,6 +204,7 @@ opendmarc_util_finddomain(u_char *raw, u_char *buf, size_t buflen)
 #define OPENDMARC_MAX_QUOTES (256)
 	int	quotes[OPENDMARC_MAX_QUOTES + 1];
 	int	numquotes = 0;
+	int	indquote = 0;
 	size_t  len;
 
 	if (raw == NULL)
@@ -242,10 +243,33 @@ opendmarc_util_finddomain(u_char *raw, u_char *buf, size_t buflen)
 				continue;
 			}
 		}
+		/*
+		 * Handle quoted-pair inside a double-quoted string (RFC5322 3.2.4).
+		 * Prevents escaped quotes from being misread as string delimiters,
+		 * e.g. "\"Foo, Inc.\"" <user@example.com>.
+		 */
+		if (indquote && *cp == '\\')
+		{
+			++cp;
+			if (*cp == '\0')
+				break;
+			if (*cp == '"' || *cp == '\\')
+			{
+				*cp = ' ';
+				continue;
+			}
+		}
 		if (*cp == '"' || *cp == '\'' || *cp == '(')
 		{
 			if (*cp == '(')
 				*cp = ')';
+			else if (*cp == '"')
+			{
+				if (!indquote)
+					indquote = 1;
+				else
+					indquote = 0;
+			}
 			if (numquotes == 0)
 			{
 				quotes[numquotes] = *cp;

--- a/libopendmarc/tests/test_finddomain.c
+++ b/libopendmarc/tests/test_finddomain.c
@@ -22,7 +22,9 @@ main(int argc, char **argv)
 		/* 10 */ {"\"Mandel, Bob\" <joe@joe.com>", "joe.com"},
 		/* 11 */ {"(,) joe@joe.com", "joe.com"},
 		/* 12 */ {"\"( bob@bob.com)\" joe@joe.com", "joe.com"},
-		/* 12 */ {"From: Davide D'Marco <user@blah.com>", "blah.com"},
+		/* 13 */ {"From: Davide D'Marco <user@blah.com>", "blah.com"},
+		/* 14 */ {"From: \"\\\"Micron Technology, Inc.\\\"\" <user@blah.com>", "blah.com"},
+		/* 15 */ {"From: \"Joe J, <joe@joe.com>\" <joe@blah.com>", "blah.com"},
 			 {NULL, NULL},
 	};
 	u_char dbuf[256];


### PR DESCRIPTION
Implements the fix from PR #75 (issue #72), cleaned up.

## Problem

RFC5322 section 3.2.4 allows backslash-escaped characters inside
quoted strings (quoted-pair). A From header like:

```
From: "\"Medtronic, Inc.\"" <user@example.com>
```

caused the escaped inner `\"` to be misread as a closing quote
delimiter. With the outer quote closed early, the `,` in `Inc.` was
then unquoted, truncating the address at that point. The parser
returned `Medtronic` as the domain instead of `example.com`, causing
DMARC to reject a legitimate message.

## Fix

Track whether we are inside a double-quoted string (`indquote`). When
inside one, a `\` followed by `"` or `\` is a quoted-pair: advance
past the backslash and blank the escaped character without passing it
to the quote-state machine.

## Changes from PR #75

- Fixed typo (`indqoute` -> `indquote`)
- Removed the redundant `else if (*cp == quotes[numquotes-1])` check
  (already known true inside the `else if (*cp == '"')` branch)
- Renumbered the duplicate test case 12

Closes #75, closes #72.