### PR TITLE
libopendmarc: make check_domain() static

### DIFF
--- a/libopendmarc/opendmarc_policy.c
+++ b/libopendmarc/opendmarc_policy.c
@@ -35,7 +35,7 @@
 **  	TRUE if the syntax was fine, FALSE otherwise.
 */
 
-bool check_domain(u_char *domain)
+static bool check_domain(u_char *domain)
 {
 	u_char *dp;
 


### PR DESCRIPTION
Applies the fix from PR #177, reported by the Debian packaging team.

`check_domain()` in `libopendmarc/opendmarc_policy.c` is used only
within that file, has no declaration in any header, and does not follow
the `opendmarc_` naming convention for public library symbols. It was
accidentally exported into the public ABI.

Adding `static` fixes the linkage without any functional change.

Closes #177.