### PR TITLE
opendmarc_tld_read_file: free hash context on fopen failure

### DIFF
--- a/libopendmarc/opendmarc_tld.c
+++ b/libopendmarc/opendmarc_tld.c
@@ -134,8 +134,11 @@ opendmarc_tld_read_file(char *path_fname, char *commentstring, char *drop, char 
 		return (errno == 0) ? ENOMEM : errno;
 
 	fp = fopen(path_fname, "r");
-	if (fp == NULL)
-		return errno;
+	if (fp == NULL) {
+		ret = errno;
+		opendmarc_hash_shutdown(hashp);
+		return ret;
+	}
 
 	errno = 0;
 	while (fgets((char *)buf, sizeof buf, fp) != NULL)


### PR DESCRIPTION
Applies the fix from PR #135 (originally reported on SourceForge ticket 212).

`opendmarc_tld_read_file()` initialises a hash context before opening
the TLD file. If `fopen()` fails, the original code returned `errno`
directly, leaking the allocated hash context.

The fix saves `errno`, calls `opendmarc_hash_shutdown()` to free the
context, then returns the saved error code.

Closes #135.