### PR TITLE
opendmarc: suppress empty brackets in startup syslog message

### DIFF
--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -5140,8 +5140,11 @@ main(int argc, char **argv)
 			n -= status;
 		}
 
-		syslog(LOG_INFO, "%s v%s starting (%s)", DMARCF_PRODUCT,
-		       VERSION, argstr);
+		syslog(LOG_INFO, "%s v%s starting%s%s%s", DMARCF_PRODUCT,
+		       VERSION,
+		       strlen(argstr) == 0 ? "" : " (",
+		       argstr,
+		       strlen(argstr) == 0 ? "" : ")");
 
 		memset(argstr, '\0', sizeof argstr);
 		strlcpy(argstr, "(none)", sizeof argstr);


### PR DESCRIPTION
Applies the fix from PR #173 (also merged in OpenDKIM as PR #65).

When opendmarc is started with no relevant command-line options,
`argstr` is empty and the startup log message read:

    opendmarc vX.Y.Z starting ()

The parentheses are now omitted when there are no options to show.

Closes #173.