### PR TITLE
opendmarc: insert A-R and software headers at index 0

### DIFF
--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -2983,7 +2983,7 @@ mlfi_eom(SMFICTX *ctx)
 					 authservid_hdr, pass_fail, use_domain);
 			}
 
-			if (dmarcf_insheader(ctx, 1, AUTHRESULTSHDR,
+			if (dmarcf_insheader(ctx, 0, AUTHRESULTSHDR,
 					     header) == MI_FAILURE)
 			{
 				if (conf->conf_dolog)
@@ -3050,7 +3050,7 @@ mlfi_eom(SMFICTX *ctx)
 		         "%s; dmarc=permerror header.from=%s",
 		         authservid_hdr, dfc->mctx_fromdomain);
 
-		if (dmarcf_insheader(ctx, 1, AUTHRESULTSHDR,
+		if (dmarcf_insheader(ctx, 0, AUTHRESULTSHDR,
 		                     header) == MI_FAILURE)
 		{
 			if (conf->conf_dolog)
@@ -3635,7 +3635,7 @@ mlfi_eom(SMFICTX *ctx)
 		         authservid_hdr,
 		         aresult, apolicy, adisposition, dfc->mctx_fromdomain);
 
-		if (dmarcf_insheader(ctx, 1, AUTHRESULTSHDR,
+		if (dmarcf_insheader(ctx, 0, AUTHRESULTSHDR,
 		                     header) == MI_FAILURE)
 		{
 			if (conf->conf_dolog)
@@ -3727,7 +3727,7 @@ mlfi_eom(SMFICTX *ctx)
 		         dfc->mctx_jobid != NULL ? dfc->mctx_jobid
 		                                 : JOBIDUNKNOWN);
 
-		if (dmarcf_insheader(ctx, 1, SWHEADERNAME,
+		if (dmarcf_insheader(ctx, 0, SWHEADERNAME,
 		                     header) == MI_FAILURE)
 		{
 			if (conf->conf_dolog)


### PR DESCRIPTION
Applies the fix from PR #171, fixing issue #23.

RFC 8601 sections 4 and 7.1 require `Authentication-Results` to be
inserted *before* the MTA's `Received` header. SpamAssassin and other
downstream verifiers rely on this ordering to determine which A-R
headers originated from a trusted hop.

With index `1`, the header was inserted after the first existing
header (typically `Received`), putting it in the wrong position.
Index `0` prepends it before all existing headers.

The identical fix was applied to OpenDKIM as PR #346 (issue #24),
credited there to @glts and @fanto666.

Closes #23.