### PR TITLE
opendmarc-check: print correct domain in multi-domain loop

### DIFF
--- a/opendmarc/opendmarc-check.c
+++ b/opendmarc/opendmarc-check.c
@@ -223,7 +223,7 @@ main(int argc, char **argv)
 		rua = opendmarc_policy_fetch_rua(dmarc, NULL, 0, 1);
 		ruf = opendmarc_policy_fetch_ruf(dmarc, NULL, 0, 1);
 
-		fprintf(stdout, "DMARC record for %s:\n", argv[1]);
+		fprintf(stdout, "DMARC record for %s:\n", argv[c]);
 		fprintf(stdout, "\tSample percentage: %d\n", pct);
 		fprintf(stdout, "\tDKIM alignment: %s\n", adkim);
 		fprintf(stdout, "\tSPF alignment: %s\n", aspf);


### PR DESCRIPTION
Applies the fix from PR #209.

When `opendmarc-check` is passed multiple domain arguments, the loop
processes each one via `argv[c]` correctly, but the output line
`DMARC record for %s:` always printed `argv[1]`. Fixed to use `argv[c]`.

Closes #209.