### PR TITLE
opendmarc-import: canonicalize domain names to lowercase on import

### DIFF
--- a/reports/opendmarc-import.in
+++ b/reports/opendmarc-import.in
@@ -675,7 +675,7 @@ while (<$inputfh>)
 	}
 	elsif ($key eq "from")
 	{
-		$fdomain = $value;
+		$fdomain = lc($value);
 	}
 	elsif ($key eq "job")
 	{
@@ -719,7 +719,7 @@ while (<$inputfh>)
 	}
 	elsif ($key eq "mfrom")
 	{
-		$envdomain = $value;
+		$envdomain = lc($value);
 	}
 	elsif ($key eq "p")
 	{
@@ -731,7 +731,7 @@ while (<$inputfh>)
 	}
 	elsif ($key eq "pdomain")
 	{
-		$pdomain = $value;
+		$pdomain = lc($value);
 	}
 	elsif ($key eq "policy")
 	{


### PR DESCRIPTION
Applies the fix from PR #143 (originally SourceForge ticket 204).

Domain names are case-insensitive by DNS spec, but `opendmarc-import`
stored whatever case appeared in the first history file entry for a
domain. If that first message was from a spammer using `EXAMPLE.COM`
in the From header, all subsequent aggregate reports for that domain
would be labelled `EXAMPLE.COM` rather than `example.com`.

Apply `lc()` to `fdomain`, `envdomain`, and `pdomain` when reading
from the history file, giving a canonical lowercase form regardless of
what arrived first.

Note: the original patch targeted the now-removed `use Switch` block;
applied here to the equivalent `if/elsif/else` code.

Closes #143.