### PR TITLE
README: fix arc and arc_policy history file value documentation

### DIFF
--- a/opendmarc/README
+++ b/opendmarc/README
@@ -180,9 +180,9 @@ their encodings, but there are only a few of them:
 			17 = quarantine
 			18 = none
 
-	arc		ARC evaluation (0 = pass, 2 = fail)
+	arc		ARC evaluation (0 = pass, 7 = fail)
 
-	arc_policy	ARC local policy evaluation (evaluation -- same as ARC, ARC seal
+	arc_policy	ARC local policy evaluation (evaluation -- (0 = pass, 2 = fail), ARC seal
 			data - JSON-encoded array of governing arc seal fields: instance,
 			domain, selector)
 


### PR DESCRIPTION
Applies the fix from PR #215 (issue #214).

The history file documentation in `opendmarc/README` had two errors:

- `arc` was documented as `(0 = pass, 2 = fail)` but `2` is
  `ARES_RESULT_SOFTFAIL`; the actual fail value is `ARES_RESULT_FAIL = 7`
- `arc_policy` said "evaluation -- same as ARC" but it uses a separate
  set of constants (`DMARC_ARC_POLICY_RESULT_PASS = 0`,
  `DMARC_ARC_POLICY_RESULT_FAIL = 2`)

Closes #215.