### PR TITLE
libopendmarc: add LIBRESOLV to LIBADD to fix underlinking on glibc <= 2.33

### DIFF
--- a/libopendmarc/Makefile.am
+++ b/libopendmarc/Makefile.am
@@ -15,5 +15,6 @@ libopendmarc_la_SOURCES	= dmarc.h \
 			  opendmarc_spf_dns.c \
                           opendmarc_internal.h
 libopendmarc_la_LDFLAGS = -version-info $(LIBOPENDMARC_VERSION_INFO)
+libopendmarc_la_LIBADD = $(LIBRESOLV)
 libopendmarc_includedir = $(includedir)/opendmarc
 libopendmarc_include_HEADERS = dmarc.h


### PR DESCRIPTION
Applies the fix from PR #218.

On glibc 2.33 and older, `__res_nquery`, `__dn_expand`, and
`__dn_skipname` live in `-lresolv` rather than libc. `configure.ac`
already detects this and sets `LIBRESOLV=-lresolv` via `AC_SUBST`, but
`libopendmarc/Makefile.am` never passed it to the shared library link
command via `LIBADD`. Builders using `-Wl,--no-undefined` (as Gentoo
does) saw undefined reference errors at link time.

See: https://bugs.gentoo.org/839951

Closes #218.