### PR TITLE
opendmarc_policy_check_alignment: fix strict mode false positive with PSL

### DIFF
--- a/libopendmarc/opendmarc_policy.c
+++ b/libopendmarc/opendmarc_policy.c
@@ -307,6 +307,13 @@ opendmarc_policy_check_alignment(u_char *subdomain, u_char *tld, int mode)
 	if (strcasecmp(rev_tld, rev_sub) == 0)
 		return 0;
 
+	/*
+	 * RFC 7489 §3.1.1/3.1.2: strict mode requires exact match only.
+	 * Do not fall through to organizational-domain resolution.
+	 */
+	if (mode == DMARC_RECORD_A_STRICT)
+		return -1;
+
 	ret = strncasecmp(rev_tld, rev_sub, strlen(rev_tld));
 	if (ret == 0 && mode == DMARC_RECORD_A_RELAXED)
 			return 0;


### PR DESCRIPTION
Fixes a bug in `opendmarc_policy_check_alignment` where strict alignment
mode (`adkim=s` or `aspf=s`) could incorrectly return aligned when a
Public Suffix List is configured.

**The bug**: After the initial exact-match check fails, the function
calls `opendmarc_get_tld()` to resolve the organizational domain of the
`tld` parameter. One of the call sites (line 545) passes `from_domain`
as `tld`. If `from_domain` is `sub.example.com` and the signing domain
is `example.com`, the PSL lookup reduces `from_domain` to `example.com`,
which then matches exactly - returning aligned even in strict mode.

**Example** (with PSL configured, adkim=s):

    From: user@sub.example.com
    DKIM d=: example.com

    Expected: FAIL (strict requires exact match)
    Actual before fix: PASS (PSL lookup collapses sub.example.com to example.com)

The reverse case (`From: user@example.com`, `d=sub.example.com`) already
worked correctly.

**The fix**: Return -1 immediately after the first `strcasecmp` fails
when in strict mode. Organizational-domain resolution is only valid
for relaxed mode.

Closes #268. Original analysis and patch by @WhiteAnthrax (KAWAHARA Masashi).