### PR TITLE
opendmarc-arcares: rewrite AAR parser using shared authres_parse state machine

### DIFF
--- a/opendmarc/opendmarc-ar.c
+++ b/opendmarc/opendmarc-ar.c
@@ -17,6 +17,7 @@
 #include <ctype.h>
 #include <assert.h>
 #include <string.h>
+#include <stdlib.h>
 #ifdef ARTEST
 # include <sysexits.h>
 #endif /* ARTEST */
@@ -45,7 +46,7 @@
 #define	ARES_TOKENS		";=."
 #define	ARES_TOKENS2		"=."
 
-#define	ARES_MAXTOKENS		512
+#define	ARES_MAXTOKENS		1536
 
 /* tables */
 struct lookup
@@ -114,7 +115,7 @@ struct lookup ptypes[] =
 **  	pointers available.
 */
 
-static int
+int
 ares_tokenize(u_char *input, u_char *outbuf, size_t outbuflen,
               u_char **tokens, int ntokens)
 {
@@ -357,16 +358,17 @@ ares_xconvert(struct lookup *table, int code)
 */
 
 int
-ares_parse(u_char *hdr, struct authres *ar)
+authres_parse(u_char *hdr, struct authres *ar, u_int *instance)
 {
 	_Bool quoted;
+	_Bool ignore_res;
 	int n;
 	int ntoks;
 	int c;
 	int r = 0;
 	int state;
 	int prevstate;
-	u_char tmp[MAXHEADER + 1];
+	u_char tmp[OPENDMARC_ARCARES_MAXHEADER_LEN + 2];
 	u_char *tokens[ARES_MAXTOKENS];
 
 	assert(hdr != NULL);
@@ -380,7 +382,7 @@ ares_parse(u_char *hdr, struct authres *ar)
 		return -1;
 
 	prevstate = -1;
-	state = 0;
+	state = (instance == NULL) ? 0 : 20;
 	n = 0;
 
 	quoted = FALSE;
@@ -479,11 +481,17 @@ ares_parse(u_char *hdr, struct authres *ar)
 			/* FALLTHROUGH */
 
 		  case 3:				/* method */
-			n++;
+			ignore_res = TRUE;
+			if (n < MAXARESULTS)
+			{
+				int method = ares_convert(methods, (char *) tokens[c]);
+				if (method != ARES_METHOD_UNKNOWN)
+				{
+					ar->ares_result[n++].result_method = method;
+					ignore_res = FALSE;
+				}
+			}
 			r = 0;
-
-			ar->ares_result[n - 1].result_method = ares_convert(methods,
-			                                                    (char *) tokens[c]);
 			prevstate = state;
 			state = 4;
 
@@ -500,8 +508,11 @@ ares_parse(u_char *hdr, struct authres *ar)
 			break;
 
 		  case 5:				/* result */
-			ar->ares_result[n - 1].result_result = ares_convert(aresults,
-			                                                    (char *) tokens[c]);
+			if (!ignore_res)
+			{
+				ar->ares_result[n - 1].result_result
+				        = ares_convert(aresults, (char *) tokens[c]);
+			}
 			prevstate = state;
 			state = 6;
 
@@ -518,9 +529,12 @@ ares_parse(u_char *hdr, struct authres *ar)
 			break;
 
 		  case 8:
-			strlcpy((char *) ar->ares_result[n - 1].result_reason,
-			        (char *) tokens[c],
-			        sizeof ar->ares_result[n - 1].result_reason);
+			if (!ignore_res)
+			{
+				strlcpy((char *) ar->ares_result[n - 1].result_reason,
+				        (char *) tokens[c],
+				        sizeof ar->ares_result[n - 1].result_reason);
+			}
 
 			prevstate = state;
 			state = 9;
@@ -559,9 +573,12 @@ ares_parse(u_char *hdr, struct authres *ar)
 			{
 				r--;
 
-				strlcat((char *) ar->ares_result[n - 1].result_value[r],
-				        (char *) tokens[c],
-				        sizeof ar->ares_result[n - 1].result_value[r]);
+				if (!ignore_res)
+				{
+					strlcat((char *) ar->ares_result[n - 1].result_value[r],
+					        (char *) tokens[c],
+					        sizeof ar->ares_result[n - 1].result_value[r]);
+				}
 
 				prevstate = state;
 				state = 13;
@@ -585,7 +602,10 @@ ares_parse(u_char *hdr, struct authres *ar)
 				if (x == ARES_PTYPE_UNKNOWN)
 					return -1;
 
-				ar->ares_result[n - 1].result_ptype[r] = x;
+				if (!ignore_res)
+				{
+					ar->ares_result[n - 1].result_ptype[r] = x;
+				}
 
 				prevstate = state;
 				state = 10;
@@ -604,9 +624,12 @@ ares_parse(u_char *hdr, struct authres *ar)
 			break;
 
 		  case 11:				/* property */
-			strlcpy((char *) ar->ares_result[n - 1].result_property[r],
-			        (char *) tokens[c],
-			        sizeof ar->ares_result[n - 1].result_property[r]);
+			if (!ignore_res)
+			{
+				strlcpy((char *) ar->ares_result[n - 1].result_property[r],
+				        (char *) tokens[c],
+				        sizeof ar->ares_result[n - 1].result_property[r]);
+			}
 
 			prevstate = state;
 			state = 12;
@@ -624,11 +647,14 @@ ares_parse(u_char *hdr, struct authres *ar)
 			break;
 
 		  case 13:				/* value */
-			strlcat((char *) ar->ares_result[n - 1].result_value[r],
-			        (char *) tokens[c],
-			        sizeof ar->ares_result[n - 1].result_value[r]);
 			r++;
-			ar->ares_result[n - 1].result_props = r;
+			if (!ignore_res)
+			{
+				strlcat((char *) ar->ares_result[n - 1].result_value[r - 1],
+				        (char *) tokens[c],
+				        sizeof ar->ares_result[n - 1].result_value[r - 1]);
+				ar->ares_result[n - 1].result_props = r;
+			}
 
 			prevstate = state;
 			if (c < ntoks - 1 && tokens[c + 1][1] == '\0')
@@ -650,6 +676,52 @@ ares_parse(u_char *hdr, struct authres *ar)
 		  case 15:				/* terminal state after no-result */
 			/* any token should not appear */
 			return -1;
+
+		  case 20:				/* AAR start: expect "i" */
+			if (tokens[c][0] != 'i' ||
+			    tokens[c][1] != '\0')
+				return -1;
+
+			prevstate = state;
+			state = 21;
+
+			break;
+
+		  case 21:				/* AAR: expect "=" */
+			if (tokens[c][0] != '=' ||
+			    tokens[c][1] != '\0')
+				return -1;
+
+			prevstate = state;
+			state = 22;
+
+			break;
+
+		  case 22:				/* AAR: instance number */
+			if (!isascii(tokens[c][0]) ||
+			    !isdigit(tokens[c][0]) ||
+			    !(tokens[c][1] == '\0' ||
+			      (isascii(tokens[c][1]) &&
+			       isdigit(tokens[c][1]) &&
+			       tokens[c][2] == '\0')))
+				return -1;
+
+			*instance = (u_int) strtol((char *) tokens[c], NULL, 10);
+
+			prevstate = state;
+			state = 23;
+
+			break;
+
+		  case 23:				/* AAR: expect ";" then AR body */
+			if (tokens[c][0] != ';' ||
+			    tokens[c][1] != '\0')
+				return -1;
+
+			prevstate = state;
+			state = 0;
+
+			break;
 		}
 	}
 
@@ -674,8 +746,6 @@ ares_parse(u_char *hdr, struct authres *ar)
 **  	EX_USAGE or EX_OK
 */
 
-# define NTOKENS 256
-
 int
 main(int argc, char **argv)
 {
@@ -686,7 +756,7 @@ main(int argc, char **argv)
 	char *progname;
 	struct authres ar;
 	u_char buf[1024];
-	u_char *toks[NTOKENS];
+	u_char *toks[ARES_MAXTOKENS];
 
 	progname = (p = strrchr(argv[0], '/')) == NULL ? argv[0] : p + 1;
 
@@ -696,7 +766,7 @@ main(int argc, char **argv)
 		return EX_USAGE;
 	}
 
-	c = ares_tokenize(argv[1], buf, sizeof buf, toks, NTOKENS);
+	c = ares_tokenize(argv[1], buf, sizeof buf, toks, ARES_MAXTOKENS);
 	for (d = 0; d < c; d++)
 		printf("token %d = '%s'\n", d, toks[d]);
 

--- a/opendmarc/opendmarc-ar.h
+++ b/opendmarc/opendmarc-ar.h
@@ -18,9 +18,12 @@
 
 /* limits */
 #define	AUTHRESHDRNAME	"Authentication-Results"
-#define	MAXARESULTS	16
+#define	MAXARESULTS	32
 #define	MAXPROPS	16
 #define	MAXAVALUE	256
+
+/* buffer to cache a single header */
+#define OPENDMARC_ARCARES_MAXHEADER_LEN		4096
 
 /* ARES_METHOD_T -- type for specifying an authentication method */
 typedef int ares_method_t;
@@ -88,6 +91,39 @@ struct authres
 };
 
 /*
+**  ARES_TOKENIZE -- tokenize a string
+**
+**  Parameters:
+**  	input -- input string
+**  	outbuf -- output buffer
+**  	outbuflen -- number of bytes available at "outbuf"
+**  	tokens -- array of token pointers
+**  	ntokens -- number of token pointers available at "tokens"
+**
+**  Return value:
+**  	-1 -- not enough space at "outbuf" for tokenizing
+**  	other -- number of tokens identified
+*/
+extern int ares_tokenize __P((u_char *input, u_char *outbuf, size_t outbuflen,
+                              u_char **tokens, int ntokens));
+
+/*
+**  AUTHRES_PARSE -- parse an Authentication-Results: or
+**                  ARC-Authentication-Results: header
+**
+**  Parameters:
+**  	hdr -- NULL-terminated header field contents
+**  	ar -- a pointer to a (struct authres) loaded by values after parsing
+**  	instance -- pointer to store instance ID for AAR headers;
+**  	            if NULL, parse as AR; if non-NULL, parse as AAR
+**
+**  Return value:
+**  	0 on success, -1 on failure.
+*/
+extern int authres_parse __P((u_char *hdr, struct authres *ar,
+                              u_int *instance));
+
+/*
 **  ARES_PARSE -- parse an Authentication-Results: header, return a
 **                structure containing a parsed result
 **
@@ -95,11 +131,13 @@ struct authres
 **  	hdr -- NULL-terminated contents of an Authentication-Results:
 **  	       header field
 **  	ar -- a pointer to a (struct authres) loaded by values after parsing
-**  
+**
 **  Return value:
 **  	0 on success, -1 on failure.
 */
-
-extern int ares_parse __P((u_char *hdr, struct authres *ar));
+static inline int ares_parse(u_char *hdr, struct authres *ar)
+{
+	return authres_parse(hdr, ar, NULL);
+}
 
 #endif /* _OPENDMARC_AR_H_ */

--- a/opendmarc/opendmarc-arcares.c
+++ b/opendmarc/opendmarc-arcares.c
@@ -26,6 +26,7 @@
 # include <opendmarc_strl.h>
 #endif /* USE_DMARCSTRL_H */
 
+#include "opendmarc-ar.h"
 #include "opendmarc-arcares.h"
 #include "opendmarc.h"
 
@@ -150,84 +151,20 @@ opendmarc_arcares_strip_whitespace(u_char *string)
 int
 opendmarc_arcares_parse (u_char *hdr, struct arcares *aar)
 {
-	int result = 0;
-	u_char *tmp_ptr;
-	u_char *token;
-	u_char tmp[OPENDMARC_ARCARES_MAXHEADER_LEN + 1];
-
 	assert(hdr != NULL);
 	assert(aar != NULL);
 
-	tmp_ptr = tmp;
-
-	memset(aar, '\0', sizeof *aar);
-	memset(tmp, '\0', sizeof tmp);
-
-	// guarantee a null-terminated string
-	memcpy(tmp, hdr, MIN(strlen(hdr), sizeof tmp - 1));
-
-	while ((token = strsep((char **)&tmp_ptr, ";")) != NULL)
-	{
-		size_t leading_space_len;
-		aar_tag_t tag_code;
-		char *token_ptr;
-		char *tag_label;
-		char *tag_value;
-
-		leading_space_len = strspn(token, " \n\t");
-		token_ptr = token + leading_space_len;
-		if (*token_ptr == '\0')
-		        return 0;
-		tag_label = strsep(&token_ptr, "=");
-		tag_value = token_ptr;
-		tag_code = opendmarc_arcares_convert(aar_tags, tag_label);
-
-		switch (tag_code)
-		{
-		  case AAR_TAG_ARC:
-			snprintf(aar->arc, sizeof aar->arc, "%s=%s", tag_label, tag_value);
-			break;
-
-		  case AAR_TAG_DKIM:
-			snprintf(aar->dkim, sizeof aar->dkim, "%s=%s", tag_label, tag_value);
-			break;
-
-		  case AAR_TAG_DMARC:
-			snprintf(aar->dmarc, sizeof aar->dmarc, "%s=%s", tag_label, tag_value);
-			break;
-
-		  case AAR_TAG_INSTANCE:
-			aar->instance = atoi(tag_value);
-			/* next value will be unlabeled authserv_id */
-			if ((token = strsep((char **) &tmp_ptr, ";")) != NULL)
-			{
-				leading_space_len = strspn(token, " \n\t");
-				tag_value = opendmarc_arcares_strip_whitespace(token);
-				strlcpy(aar->authserv_id, tag_value, sizeof aar->authserv_id);
-			}
-			break;
-
-		  case AAR_TAG_SPF:
-			snprintf(aar->spf, sizeof aar->spf, "%s=%s", tag_label, tag_value);
-			break;
-
-		  default:
-			result = -1;
-			break;
-		}
-	}
-
-	return result;
+	return authres_parse(hdr, &(aar->payload), &(aar->instance));
 }
 
 /*
-** OPENDMARC_ARCARES_ARC_PARSE -- parse an ARC-Authentication-Results: header
-**                                ARC field, return a structure containing parse
-**                                result
+** OPENDMARC_ARCARES_ARC_PARSE -- retrieve ARC result from a parsed
+**                                ARC-Authentication-Results: header result,
+**                                return a structure containing ARC-specific
+**                                parse result (especially client-ip)
 **
 ** Parameters:
-** 	hdr_arc -- NULL-terminated contents of an ARC-Authentication-Results:
-**                 header ARC field
+** 	aar -- a parse result structure populated by opendmarc_arcares_parse
 ** 	arc -- a pointer to a struct (arcares_arc_field) loaded by values after
 **             parsing
 **
@@ -236,60 +173,53 @@ opendmarc_arcares_parse (u_char *hdr, struct arcares *aar)
 **/
 
 int
-opendmarc_arcares_arc_parse (u_char *hdr_arc, struct arcares_arc_field *arc)
+opendmarc_arcares_arc_parse (struct arcares *aar,
+                             struct arcares_arc_field *arc)
 {
-	u_char *tmp_ptr;
-	u_char *token;
-	u_char tmp[OPENDMARC_ARCARES_MAXHEADER_LEN + 1];
-	int result = 0;
+	int cr;
+	int cp;
+	int r_found = 0;
+	int p_found = 0;
 
-	tmp_ptr = tmp;
-
-	assert(hdr_arc != NULL);
+	assert(aar != NULL);
 	assert(arc != NULL);
 
 	memset(arc, '\0', sizeof *arc);
-	memset(tmp, '\0', sizeof tmp);
 
-	memcpy(tmp, hdr_arc, MIN_OF(strlen(hdr_arc), sizeof tmp - 1));
-
-	while ((token = strsep((char **)&tmp_ptr, ";")) != NULL)
+	for (cr = 0; cr < aar->payload.ares_count; cr++)
 	{
-		size_t leading_space_len;
-		aar_tag_t tag_code;
-		char *token_ptr;
-		char *tag_label;
-		char *tag_value;
-
-		leading_space_len = strspn(token, " \n\t");
-		token_ptr = token + leading_space_len;
-		if (*token_ptr == '\0')
-			return 0;
-		tag_label = strsep(&token_ptr, "=");
-		tag_value = opendmarc_arcares_strip_whitespace(token_ptr);
-		tag_code = opendmarc_arcares_convert(aar_arc_tags, tag_label);
-
-		switch (tag_code)
+		if (aar->payload.ares_result[cr].result_method == ARES_METHOD_ARC)
 		{
-		  case AAR_ARC_TAG_ARC:
-			strlcpy(arc->arcresult, tag_value, sizeof arc->arcresult);
-			break;
+			if (r_found++)
+				return -1;
 
-		  case AAR_ARC_TAG_ARC_CHAIN:
-			strlcpy(arc->arcchain, tag_value, sizeof arc->arcchain);
-			break;
+			memcpy(&(arc->arcresult), &(aar->payload.ares_result[cr]),
+			       sizeof arc->arcresult);
 
-		  case AAR_ARC_TAG_SMTP_CLIENT_IP:
-			strlcpy(arc->smtpclientip, tag_value, sizeof arc->smtpclientip);
-			break;
+			for (cp = 0; cp < arc->arcresult.result_props; cp++)
+			{
+				/* old OpenARC implementations used "client-ip" */
+				if (arc->arcresult.result_ptype[cp] == ARES_PTYPE_SMTP &&
+				    (strcasecmp((char *) arc->arcresult.result_property[cp],
+				                "remote-ip") == 0 ||
+				     strcasecmp((char *) arc->arcresult.result_property[cp],
+				                "client-ip") == 0))
+				{
+					if (p_found++)
+						return -1;
 
-		  default:
-		  	result = -1;
-			break;
+					strlcpy(arc->smtpclientip,
+					        (char *) arc->arcresult.result_value[cp],
+					        sizeof arc->smtpclientip);
+				}
+			}
+
+			if (!p_found)
+				return -1;
 		}
 	}
 
-	return result;
+	return r_found ? 0 : -1;
 }
 
 /*
@@ -319,13 +249,7 @@ opendmarc_arcares_list_pluck(u_int instance, struct arcares_header *aar_hdr,
 	{
 		if (aar_hdr->arcares.instance == instance)
 		{
-			aar->instance = aar_hdr->arcares.instance;
-			strlcpy(aar->authserv_id, aar_hdr->arcares.authserv_id, sizeof aar->authserv_id);
-			strlcpy(aar->arc, aar_hdr->arcares.arc, sizeof aar->arc);
-			strlcpy(aar->dkim, aar_hdr->arcares.dkim, sizeof aar->dkim);
-			strlcpy(aar->dmarc, aar_hdr->arcares.dmarc, sizeof aar->dmarc);
-			strlcpy(aar->spf, aar_hdr->arcares.spf, sizeof aar->spf);
-
+			memcpy(aar, &(aar_hdr->arcares), sizeof *aar);
 			return 0;
 		}
 

--- a/opendmarc/opendmarc-arcares.h
+++ b/opendmarc/opendmarc-arcares.h
@@ -13,6 +13,7 @@
 #include <sys/types.h>
 
 /* opendmarc includes */
+#include "opendmarc-ar.h"
 #include "parse.h"
 
 /* boolean TRUE and FALSE */
@@ -27,8 +28,6 @@
 ** limits
 */
 
-/* buffer to cache a single header */
-#define OPENDMARC_ARCARES_MAXHEADER_LEN       4096
 /* max header tag value length (short) */
 #define OPENDMARC_ARCARES_MAX_SHORT_VALUE_LEN 256
 /* max header tag value length (long) */
@@ -66,12 +65,8 @@ struct arcares_field
 /* ARCARES structure -- the single header parsed */
 struct arcares
 {
-	int instance;
-	u_char authserv_id[OPENDMARC_ARCARES_MAX_SHORT_VALUE_LEN + 1];
-	u_char arc[OPENDMARC_ARCARES_MAX_LONG_VALUE_LEN + 1];
-	u_char dkim[OPENDMARC_ARCARES_MAX_LONG_VALUE_LEN + 1];
-	u_char dmarc[OPENDMARC_ARCARES_MAX_LONG_VALUE_LEN + 1];
-	u_char spf[OPENDMARC_ARCARES_MAX_LONG_VALUE_LEN + 1];
+	u_int instance;
+	struct authres payload;
 };
 
 /* ARCARES_HEADER -- a node for a linked list of arcares structs */
@@ -84,7 +79,7 @@ struct arcares_header
 
 struct arcares_arc_field
 {
-	u_char arcresult[OPENDMARC_ARCARES_MAX_SHORT_VALUE_LEN + 1];
+	struct result arcresult;
 	u_char smtpclientip[OPENDMARC_ARCARES_MAX_SHORT_VALUE_LEN + 1];
 	u_char arcchain[OPENDMARC_ARCARES_MAX_LONG_VALUE_LEN + 1];
 };
@@ -105,13 +100,13 @@ struct arcares_arc_field
 extern int opendmarc_arcares_parse __P((u_char *hdr, struct arcares *aar));
 
 /*
-** OPENDMARC_ARCARES_ARC+PARSE -- parse an ARC-Authentication-Results: header
-**                                ARC field, return a structure containing parse
-**                                result
+** OPENDMARC_ARCARES_ARC_PARSE -- retrieve ARC result from a parsed
+**                                ARC-Authentication-Results: header result,
+**                                return a structure containing ARC-specific
+**                                parse result (especially client-ip)
 **
 ** Parameters:
-** 	hdr_arc -- NULL-terminated contents of an ARC-Authentication-Results:
-**                 header ARC field
+** 	aar -- a parse result structure populated by opendmarc_arcares_parse
 ** 	arc -- a pointer to a struct (arcares_arc_field) loaded by values after
 **             parsing
 **
@@ -119,7 +114,7 @@ extern int opendmarc_arcares_parse __P((u_char *hdr, struct arcares *aar));
 **  	0 on success, -1 on failure
 **/
 
-extern int opendmarc_arcares_arc_parse __P((u_char *hdr_arc,
+extern int opendmarc_arcares_arc_parse __P((struct arcares *aar,
                                             struct arcares_arc_field *arc));
 
 /*

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -3601,13 +3601,17 @@ mlfi_eom(SMFICTX *ctx)
 	     dfc->mctx_aarhead != NULL && as_hdr != NULL;
 	     as_hdr = as_hdr->arcseal_next, c++)
 	{
-		/* fetch smtp.client_ip from aar */
+		/* make sure smtpclientip is (re)initialized before use */
+		arcares_arc_field.smtpclientip[0] = '\0';
+
+		/* fetch smtp.remote-ip from aar */
 		if (opendmarc_arcares_list_pluck(as_hdr->arcseal.instance,
 		                                 dfc->mctx_aarhead,
 		                                 &arcares) == 0)
 		{
-			(void) opendmarc_arcares_arc_parse(arcares.arc,
-			                                   &arcares_arc_field);
+			if (opendmarc_arcares_arc_parse(&arcares,
+			                               &arcares_arc_field) != 0)
+				arcares_arc_field.smtpclientip[0] = '\0';
 		}
 
 		dmarcf_dstring_printf(dfc->mctx_histbuf,


### PR DESCRIPTION
Replaces the bespoke `strsep`-based ARC-Authentication-Results parser with
a unified `authres_parse()` function that handles both AR and AAR headers,
sharing the existing tokenizer and state machine.

**Changes from upstream PR #305:**

- Rebased onto develop; conflict with #267 (states 14/15 for `none` result)
  resolved cleanly - the `ignore_res` logic in case 3 composes correctly
  with the none-handling fallthrough from case 14
- Fixed `inline int ares_parse` in the header - must be `static inline`
  to avoid multiple-definition link errors
- Fixed inverted `strcasecmp` comparisons in `opendmarc_arcares_arc_parse`
  for `remote-ip`/`client-ip` property matching: the original PR used
  `strcasecmp(...) || strcasecmp(...)` without `== 0`, which is truthy when
  strings do NOT match, causing the field to match everything rather than
  just those two property names

**Summary of functional changes:**

- `authres_parse(hdr, ar, instance)` unifies AR and AAR parsing; `ares_parse`
  becomes a `static inline` wrapper for backwards compatibility
- AAR `i=N;` prefix parsed via states 20-23 before transitioning to the
  normal AR body state machine
- `ares_tokenize()` made non-static for sharing
- `MAXARESULTS` doubled to 32; `ARES_MAXTOKENS` tripled to 1536
- `ignore_res` flag skips storing results for unrecognized method names
  instead of failing, improving forward compatibility with new methods
- `opendmarc_arcares_arc_parse()` now operates on the already-parsed struct
  rather than re-parsing a raw string
- `struct arcares` fields replaced by `struct authres payload` + `u_int instance`
- `opendmarc_arcares_list_pluck()` simplified to a single `memcpy`

Original design and implementation by @futatuki (FUTATSUKI Yasuhito).
Closes #305.