### PR TITLE
Replace AUTHRESHDRNAME with AUTHRESULTSHDR, remove duplicate macro

### DIFF
--- a/opendmarc/opendmarc-ar.h
+++ b/opendmarc/opendmarc-ar.h
@@ -17,7 +17,6 @@
 #include "dmarc.h"
 
 /* limits */
-#define	AUTHRESHDRNAME	"Authentication-Results"
 #define	MAXARESULTS	32
 #define	MAXPROPS	16
 #define	MAXAVALUE	256

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -2496,7 +2496,7 @@ mlfi_eom(SMFICTX *ctx)
 	     hdr = hdr->hdr_next, c++)
 	{
 		/* skip it if it's not Authentication-Results */
-		if (strcasecmp(hdr->hdr_name, AUTHRESHDRNAME) != 0)
+		if (strcasecmp(hdr->hdr_name, AUTHRESULTSHDR) != 0)
 			continue;
 
 		/* parse it */


### PR DESCRIPTION
`AUTHRESHDRNAME` in `opendmarc-ar.h` and `AUTHRESULTSHDR` in `opendmarc.h` both define the same string `"Authentication-Results"`. Remove the duplicate and use `AUTHRESULTSHDR` consistently throughout.

Closes #20.