### PR TITLE
Add RejectString config option for customizable DMARC rejection message (issue #74)

### DIFF
--- a/opendmarc/opendmarc-config.h
+++ b/opendmarc/opendmarc-config.h
@@ -47,6 +47,7 @@ struct configdef dmarcf_config[] =
 	{ "RequiredHeaders",		CONFIG_TYPE_BOOLEAN,	FALSE },
 	{ "RejectFailures",		CONFIG_TYPE_BOOLEAN,	FALSE },
 	{ "RejectMultiValueFrom",	CONFIG_TYPE_BOOLEAN,	FALSE },
+	{ "RejectString",		CONFIG_TYPE_STRING,	FALSE },
 	{ "ReportCommand",		CONFIG_TYPE_STRING,	FALSE },
 	{ "Socket",			CONFIG_TYPE_STRING,	FALSE },
 	{ "SoftwareHeader",		CONFIG_TYPE_BOOLEAN,	FALSE },

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -190,6 +190,7 @@ struct dmarcf_config
 	char *			conf_historyfile;
 	char *			conf_pslist;
 	char *			conf_ignorelist;
+	char *			conf_rejectstring;
 	char **			conf_trustedauthservids;
 	char **			conf_ignoredomains;
 	struct list *		conf_domainwhitelist;
@@ -1419,6 +1420,10 @@ dmarcf_config_load(struct config *data, struct dmarcf_config *conf,
 		                  &conf->conf_rejectfail,
 		                  sizeof conf->conf_rejectfail);
 
+		(void) config_get(data, "RejectString",
+		                  &conf->conf_rejectstring,
+		                  sizeof conf->conf_rejectstring);
+
 		(void) config_get(data, "RequiredHeaders",
 		                  &conf->conf_reqhdrs,
 		                  sizeof conf->conf_reqhdrs);
@@ -1626,6 +1631,30 @@ dmarcf_config_load(struct config *data, struct dmarcf_config *conf,
 	}
 
 	pthread_rwlock_unlock(&hash_lock);
+
+	if (conf->conf_rejectstring == NULL)
+	{
+		conf->conf_rejectstring = DEFREJECTSTR;
+	}
+	else
+	{
+		int countocc = 0;
+		const char *tmp = conf->conf_rejectstring;
+
+		while ((tmp = strstr(tmp, "%s")) != NULL)
+		{
+			countocc++;
+			tmp++;
+		}
+
+		if (countocc > 1)
+		{
+			snprintf(err, errlen,
+			         "%s: RejectString contains more than one %%s",
+			         basedir);
+			return -1;
+		}
+	}
 
 	return 0;
 }
@@ -3560,8 +3589,12 @@ mlfi_eom(SMFICTX *ctx)
 		if (conf->conf_rejectfail &&
 		    random() % 100 < pct)
 		{
-			snprintf(replybuf, sizeof replybuf,
-			         "rejected by DMARC policy for %s", pdomain);
+			if (strstr(conf->conf_rejectstring, "%s") != NULL)
+				snprintf(replybuf, sizeof replybuf,
+				         conf->conf_rejectstring, pdomain);
+			else
+				snprintf(replybuf, sizeof replybuf,
+				         "%s", conf->conf_rejectstring);
 
 			status = dmarcf_setreply(ctx, DMARC_REJECT_SMTP,
 			                         DMARC_REJECT_ESC, replybuf);

--- a/opendmarc/opendmarc.conf.5.in
+++ b/opendmarc/opendmarc.conf.5.in
@@ -262,6 +262,18 @@ will be rejected unless all domain names in that field are the same.  They
 will otherwise be ignored by the filter (the default).
 
 .TP
+.I RejectString (string)
+Specifies the SMTP rejection message used when a message is rejected due to
+DMARC policy.  The string may optionally contain one
+.B %s
+which will be replaced by the RFC5322.From domain.  If
+.B %s
+is omitted the string is used as-is.  The string may not contain more than
+one
+.B %s.
+The default is "rejected by DMARC policy for %s".
+
+.TP
 .I ReportCommand (string)
 Indicates the shell command to which failure reports should be passed for
 delivery when

--- a/opendmarc/opendmarc.conf.sample
+++ b/opendmarc/opendmarc.conf.sample
@@ -311,6 +311,15 @@
 # 
 # RejectMultiValueFrom false
 
+##  RejectString string
+##      default "rejected by DMARC policy for %s"
+##
+##  Specifies the SMTP rejection message used when a message is rejected due
+##  to DMARC policy.  May contain at most one %s, which is replaced by the
+##  RFC5322.From domain.  If %s is omitted, the string is used as-is.
+#
+# RejectString rejected by DMARC policy for %s
+
 ##  ReportCommand string
 ##  	default "/usr/sbin/sendmail -t"
 ##

--- a/opendmarc/opendmarc.h
+++ b/opendmarc/opendmarc.h
@@ -33,6 +33,7 @@
 /* defaults, limits, etc. */
 #define	BUFRSZ		2048
 #define	DEFCONFFILE	CONFIG_BASE "/opendmarc.conf"
+#define	DEFREJECTSTR	"rejected by DMARC policy for %s"
 #define	DEFREPORTCMD	"/usr/sbin/sendmail -t -odq"
 #define	JOBIDUNKNOWN	"(unknown-jobid)"
 #define	MAXARGV		65536


### PR DESCRIPTION
## Summary

Adds a `RejectString` configuration option that allows site administrators to customize the SMTP rejection message returned when a message fails DMARC policy and `RejectFailures yes` is set.

- The string may contain one `%s`, which is replaced by the RFC5322.From domain at rejection time
- More than one `%s` is treated as a configuration error at startup
- If `%s` is omitted the string is used verbatim
- Defaults to `"rejected by DMARC policy for %s"` (preserving current behavior)

## Test plan

- [ ] Default behavior unchanged when `RejectString` is not set
- [ ] Custom string without `%s` is sent verbatim in the SMTP 550 response
- [ ] Custom string with `%s` has the From domain substituted correctly
- [ ] More than one `%s` in the string is rejected at config load time

Fixes #74