### PR TITLE
Add RejectString config option for customizable DMARC rejection message (issue #74)

### DIFF
--- a/opendmarc/opendmarc-config.h
+++ b/opendmarc/opendmarc-config.h
@@ -48,6 +48,7 @@ struct configdef dmarcf_config[] =
 	{ "RequiredFrom",		CONFIG_TYPE_BOOLEAN,	FALSE },
 	{ "RejectFailures",		CONFIG_TYPE_BOOLEAN,	FALSE },
 	{ "RejectMultiValueFrom",	CONFIG_TYPE_BOOLEAN,	FALSE },
+	{ "RejectString",		CONFIG_TYPE_STRING,	FALSE },
 	{ "ReportCommand",		CONFIG_TYPE_STRING,	FALSE },
 	{ "Socket",			CONFIG_TYPE_STRING,	FALSE },
 	{ "SoftwareHeader",		CONFIG_TYPE_BOOLEAN,	FALSE },

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -191,6 +191,7 @@ struct dmarcf_config
 	char *			conf_reportcmd;
 	char *			conf_authservid;
 	char *			conf_historyfile;
+	char *			conf_rejectstring;
 	char *			conf_pslist;
 	char *			conf_ignorelist;
 	char **			conf_trustedauthservids;
@@ -1239,6 +1240,10 @@ dmarcf_config_load(struct config *data, struct dmarcf_config *conf,
 		                  &conf->conf_rejectfail,
 		                  sizeof conf->conf_rejectfail);
 
+		(void) config_get(data, "RejectString",
+		                  &conf->conf_rejectstring,
+		                  sizeof conf->conf_rejectstring);
+
 		(void) config_get(data, "RequiredHeaders",
 		                  &conf->conf_reqhdrs,
 		                  sizeof conf->conf_reqhdrs);
@@ -1450,6 +1455,29 @@ dmarcf_config_load(struct config *data, struct dmarcf_config *conf,
 	}
 
 	pthread_rwlock_unlock(&hash_lock);
+
+	if (conf->conf_rejectstring == NULL)
+	{
+		conf->conf_rejectstring = DEFREJECTSTR;
+	}
+	else
+	{
+		int pct_count = 0;
+		const char *p = conf->conf_rejectstring;
+
+		while ((p = strstr(p, "%s")) != NULL)
+		{
+			pct_count++;
+			p++;
+		}
+
+		if (pct_count > 1)
+		{
+			snprintf(err, errlen,
+			         "RejectString contains more than one %%s");
+			return -1;
+		}
+	}
 
 	return 0;
 }
@@ -3180,8 +3208,12 @@ mlfi_eom(SMFICTX *ctx)
 		if (conf->conf_rejectfail &&
 		    random() % 100 < pct)
 		{
-			snprintf(replybuf, sizeof replybuf,
-			         "rejected by DMARC policy for %s", pdomain);
+			if (strstr(conf->conf_rejectstring, "%s") != NULL)
+				snprintf(replybuf, sizeof replybuf,
+				         conf->conf_rejectstring, pdomain);
+			else
+				snprintf(replybuf, sizeof replybuf,
+				         "%s", conf->conf_rejectstring);
 
 			status = dmarcf_setreply(ctx, DMARC_REJECT_SMTP,
 			                         DMARC_REJECT_ESC, replybuf);

--- a/opendmarc/opendmarc.conf.5.in
+++ b/opendmarc/opendmarc.conf.5.in
@@ -260,6 +260,22 @@ the message.  Instead, an Authentication-Results header field will be added.
 The default is "false".
 
 .TP
+.I RejectString (string)
+Specifies the SMTP rejection message used when a message is rejected due to
+DMARC policy (see
+.IR RejectFailures ).
+The string may optionally contain one
+.B %s
+which is replaced by the RFC5322.From domain at rejection time.
+If
+.B %s
+is omitted the string is used verbatim.
+More than one
+.B %s
+is treated as a configuration error.
+The default is "rejected by DMARC policy for %s".
+
+.TP
 .I RejectMultiValueFrom (Boolean)
 If set, messages with multiple addresses in the From: field of the message
 will be rejected unless all domain names in that field are the same.  They

--- a/opendmarc/opendmarc.conf.sample
+++ b/opendmarc/opendmarc.conf.sample
@@ -302,6 +302,16 @@
 #
 # RejectFailures false
 
+##  RejectString string
+##  	default "rejected by DMARC policy for %s"
+##
+##  Specifies the SMTP rejection message used when a message is rejected due
+##  to DMARC policy (see RejectFailures).  May contain at most one %s, which
+##  is replaced by the RFC5322.From domain.  If %s is omitted the string is
+##  used verbatim.
+#
+# RejectString rejected by DMARC policy for %s
+
 ##  RejectMultiValueFrom { true | false }
 ##  	default "false"
 ##

--- a/opendmarc/opendmarc.h
+++ b/opendmarc/opendmarc.h
@@ -46,6 +46,7 @@
 #define	DMARC_TEMPFAIL_ESC	"4.7.1"
 #define	DMARC_REJECT_SMTP	"550"
 #define	DMARC_REJECT_ESC	"5.7.1"
+#define	DEFREJECTSTR		"rejected by DMARC policy for %s"
 
 #define	DMARC_RESULT_REJECT	0
 #define	DMARC_RESULT_DISCARD	1


### PR DESCRIPTION
## Summary

Adds a `RejectString` configuration option allowing the SMTP 550 rejection message to be customised when a message fails DMARC policy and `RejectFailures yes` is set.

- Accepts an optional `%s` placeholder, replaced by the RFC5322.From domain at rejection time
- Using more than one `%s` is rejected at config load with an error
- Omitting `%s` uses the string verbatim
- Defaults to `"rejected by DMARC policy for %s"` (existing behavior unchanged)

Reimplemented cleanly against current develop (the earlier branch `fix/issue-74-reject-string` had unresolvable conflicts with the quarantine/ARC override rework).

## Files changed

- `opendmarc/opendmarc.h` - `DEFREJECTSTR` constant
- `opendmarc/opendmarc-config.h` - config table entry
- `opendmarc/opendmarc.c` - struct field, `config_get`, validation, reject path
- `opendmarc/opendmarc.conf.5.in` - man page entry
- `opendmarc/opendmarc.conf.sample` - commented sample entry

## Test plan

- [ ] Default behavior unchanged when `RejectString` is not set
- [ ] Custom string without `%s` is sent verbatim in the SMTP 550 response
- [ ] Custom string with one `%s` substitutes the From domain correctly
- [ ] More than one `%s` is rejected at config load time with a clear error

Fixes #74