### PR TITLE
opendmarc -V: show configure args, git hash, and clarify SPF backend

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -67,6 +67,23 @@ AC_CHECK_TYPES([ns_type], [], [], [[
 ]])
 
 #
+# Version string: use git describe on dev builds for a hash suffix
+#
+AC_CHECK_PROG([GIT], [git], [git])
+AC_MSG_CHECKING([build version string])
+DMARCF_VERSION=$PACKAGE_VERSION
+if test -n "$GIT" && $GIT describe --tags --dirty >/dev/null 2>&1; then
+    _git_ver=$($GIT describe --tags --dirty)
+    _git_ver=${_git_ver#v}
+    if test "$_git_ver" != "$PACKAGE_VERSION"; then
+        DMARCF_VERSION=$_git_ver
+    fi
+fi
+AC_MSG_RESULT([$DMARCF_VERSION])
+AC_DEFINE_UNQUOTED([DMARCF_VERSION], ["$DMARCF_VERSION"],
+                   [Version string, including git hash on development builds])
+
+#
 # Hexadecimal version, for use in generating dmarc.h
 #
 HEX_VERSION=$(printf %08x $(( ((VERSION_RELEASE << 8 | VERSION_MAJOR_REV) << 8 | VERSION_MINOR_REV) << 8 | VERSION_PATCH )))

--- a/configure.ac
+++ b/configure.ac
@@ -567,5 +567,7 @@ AC_CONFIG_FILES([ Makefile
 		reports/opendmarc-reports
 		reports/opendmarc-reports.8
 	])
+AC_DEFINE_UNQUOTED([CONFIGURE_ARGS], ["$ac_configure_args"],
+                   [Arguments passed to configure])
 AC_OUTPUT()
 # @end1

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -4263,6 +4263,7 @@ main(int argc, char **argv)
 			printf("\tlibmilter version %d.%d.%d\n",
 			       mvmajor, mvminor, mvrelease);
 #endif /* HAVE_SMFI_VERSION */
+			printf("\tConfigured with: %s\n", CONFIGURE_ARGS);
 			dmarcf_optlist(stdout);
 			return EX_OK;
 

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -3448,7 +3448,7 @@ mlfi_eom(SMFICTX *ctx)
 
 			dmarcf_dstring_printf(dfc->mctx_afrf,
 			                      "User-Agent: %s/%s\n",
-			                      DMARCF_PRODUCTNS, VERSION);
+			                      DMARCF_PRODUCTNS, DMARCF_VERSION);
 
 			dmarcf_dstring_cat(dfc->mctx_afrf,
 			                   "Auth-Failure: dmarc\n");
@@ -3743,7 +3743,7 @@ mlfi_eom(SMFICTX *ctx)
 	if (conf->conf_addswhdr)
 	{
 		snprintf(header, sizeof header, "%s v%s %s %s",
-		         DMARCF_PRODUCT, VERSION, hostname,
+		         DMARCF_PRODUCT, DMARCF_VERSION, hostname,
 		         dfc->mctx_jobid != NULL ? dfc->mctx_jobid
 		                                 : JOBIDUNKNOWN);
 
@@ -4256,7 +4256,7 @@ main(int argc, char **argv)
 
 		  case 'V':
 			printf("%s: %s v%s\n", progname, DMARCF_PRODUCT,
-			       VERSION);
+			       DMARCF_VERSION);
 			printf("\tSMFI_VERSION 0x%x\n", SMFI_VERSION);
 #ifdef HAVE_SMFI_VERSION
 			(void) smfi_version(&mvmajor, &mvminor, &mvrelease);
@@ -5162,7 +5162,7 @@ main(int argc, char **argv)
 		}
 
 		syslog(LOG_INFO, "%s v%s starting%s%s%s", DMARCF_PRODUCT,
-		       VERSION,
+		       DMARCF_VERSION,
 		       strlen(argstr) == 0 ? "" : " (",
 		       argstr,
 		       strlen(argstr) == 0 ? "" : ")");
@@ -5222,7 +5222,7 @@ main(int argc, char **argv)
 	{
 		syslog(LOG_INFO,
 		       "%s v%s terminating with status %d, errno = %d",
-		       DMARCF_PRODUCT, VERSION, status, errno);
+		       DMARCF_PRODUCT, DMARCF_VERSION, status, errno);
 	}
 
 	/* release memory */

--- a/opendmarc/util.c
+++ b/opendmarc/util.c
@@ -69,12 +69,12 @@ static char *optlist[] =
 #endif /* POLL */
 
 #if WITH_SPF
-	"WITH_SPF",
+# if HAVE_SPF2_H
+	"WITH_SPF (libspf2)",
+# else /* HAVE_SPF2_H */
+	"WITH_SPF (internal)",
+# endif /* HAVE_SPF2_H */
 #endif /* WITH_SPF */
-
-#if HAVE_SPF2_H
-	"WITH_SPF2",
-#endif /* HAVE_SPF2_H */
 
 	NULL
 };


### PR DESCRIPTION
## Summary

Three related improvements to `-V` output, mirroring what was done in OpenDKIM (#366):

- **`CONFIGURE_ARGS`**: `./configure` arguments are now embedded via `AC_DEFINE_UNQUOTED`, so operators can see exactly how the binary was built.
- **Git hash in version string**: `configure.ac` runs `git describe --tags --dirty`; if the result differs from `PACKAGE_VERSION` (i.e. the build is not an exact tagged release), it becomes `DMARCF_VERSION`. Tagged release builds and environments without git fall back to the plain version number. All five `VERSION` references in `opendmarc.c` replaced with `DMARCF_VERSION`.
- **SPF backend clarity**: the redundant `WITH_SPF` + `WITH_SPF2` optlist entries are merged into a single `WITH_SPF (libspf2)` or `WITH_SPF (internal)` string.

## Example output (dev build with SPF + libspf2)

```
opendmarc: OpenDMARC Filter v1.4.2-5-gabcdef7
    SMFI_VERSION 0x1000002
    libmilter version 1.0.2
    Configured with:  '--with-spf' '--with-spf2-include=/usr/local/include/spf2' '--with-spf2-lib=/usr/local/lib'
    Active code options:
        WITH_SPF (libspf2)
```

## Test plan

- [ ] Build from a tagged commit: version string is plain `1.4.2`
- [ ] Build from an untagged commit: version string is `1.4.2-N-gHASH` (or `-dirty` suffix if tree is modified)
- [ ] Build without git in PATH: falls back to plain version number
- [ ] Build without SPF: no SPF entry in active options, `Configured with:` reflects flags used
- [ ] Build with `--with-spf`: shows `WITH_SPF (internal)`
- [ ] Build with `--with-spf --with-spf2-include=... --with-spf2-lib=...`: shows `WITH_SPF (libspf2)`
- [ ] CI passes