### PR TITLE
SoftwareHeader: include milter hostname when different from MTA hostname

### DIFF
--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -3777,10 +3777,21 @@ mlfi_eom(SMFICTX *ctx)
 
 	if (conf->conf_addswhdr)
 	{
-		snprintf(header, sizeof header, "%s v%s %s %s",
-		         DMARCF_PRODUCT, DMARCF_VERSION, hostname,
-		         dfc->mctx_jobid != NULL ? dfc->mctx_jobid
-		                                 : JOBIDUNKNOWN);
+		if (strcasecmp(hostname, myhostname) == 0)
+		{
+			snprintf(header, sizeof header, "%s v%s %s %s",
+			         DMARCF_PRODUCT, DMARCF_VERSION, hostname,
+			         dfc->mctx_jobid != NULL ? dfc->mctx_jobid
+			                                 : JOBIDUNKNOWN);
+		}
+		else
+		{
+			snprintf(header, sizeof header, "%s v%s %s via %s %s",
+			         DMARCF_PRODUCT, DMARCF_VERSION, hostname,
+			         myhostname,
+			         dfc->mctx_jobid != NULL ? dfc->mctx_jobid
+			                                 : JOBIDUNKNOWN);
+		}
 
 		if (dmarcf_insheader(ctx, 0, SWHEADERNAME,
 		                     header) == MI_FAILURE)


### PR DESCRIPTION
Mirrors OpenDKIM PR #367.

When `SoftwareHeader yes` is configured and the milter runs on the same host as the MTA, the header is unchanged:

```
DMARC-Filter: OpenDMARC Filter v1.4.2 mail.example.com AB12CD3E
```

When the milter runs on a different host (e.g. a milter pool behind a load balancer), the milter's own hostname is appended:

```
DMARC-Filter: OpenDMARC Filter v1.4.2 mail.example.com via milter1.internal AB12CD3E
```

Comparison between the MTA hostname (`{j}` macro) and the milter hostname (`gethostname()`) is case-insensitive. No config changes required.

## Test plan

- [ ] Single-host deployment: header format unchanged from current behavior
- [ ] Milter running on separate host from MTA: `via <myhostname>` appears between MTA hostname and job ID
- [ ] `SoftwareHeader no` (default): no change in behavior