### PR TITLE
fix: subdomain DMARC fallback to parent domain (issue #54)

### DIFF
--- a/libopendmarc/dmarc.h.in
+++ b/libopendmarc/dmarc.h.in
@@ -146,6 +146,7 @@ u_char **	   opendmarc_policy_fetch_rua(DMARC_POLICY_T *pctx, u_char *list_buf, 
 u_char **	   opendmarc_policy_fetch_ruf(DMARC_POLICY_T *pctx, u_char *list_buf, size_t size_of_buf, int constant);
 OPENDMARC_STATUS_T opendmarc_policy_fetch_utilized_domain(DMARC_POLICY_T *pctx, u_char *buf, size_t buflen);
 OPENDMARC_STATUS_T opendmarc_policy_fetch_from_domain(DMARC_POLICY_T *pctx, u_char *buf, size_t buflen);
+OPENDMARC_STATUS_T opendmarc_policy_fetch_org_domain_from_fallback(DMARC_POLICY_T *pctx, int *fallbackp);
 OPENDMARC_STATUS_T opendmarc_policy_query_dmarc_xdomain(DMARC_POLICY_T *pctx, u_char *uri);
 OPENDMARC_STATUS_T opendmarc_get_policy_token_used(DMARC_POLICY_T *pctx);
 

--- a/libopendmarc/opendmarc_internal.h
+++ b/libopendmarc/opendmarc_internal.h
@@ -159,6 +159,7 @@ typedef struct dmarc_policy_t {
 	 */
 	u_char *	from_domain;		/* Input: From: header domain */
 	u_char *	organizational_domain;
+	int		org_domain_from_fallback; /* Non-zero if PSL was absent and label-walk was used */
 
 	/*
 	 * Found in the _dmarc record or supplied to us.

--- a/libopendmarc/opendmarc_policy.c
+++ b/libopendmarc/opendmarc_policy.c
@@ -1661,6 +1661,18 @@ opendmarc_policy_fetch_from_domain(DMARC_POLICY_T *pctx, u_char *buf, size_t buf
 # endif
 	return DMARC_PARSE_OKAY;
 }
+
+OPENDMARC_STATUS_T
+opendmarc_policy_fetch_org_domain_from_fallback(DMARC_POLICY_T *pctx, int *fallbackp)
+{
+	if (pctx == NULL)
+		return DMARC_PARSE_ERROR_NULL_CTX;
+	if (fallbackp == NULL)
+		return DMARC_PARSE_ERROR_EMPTY;
+	*fallbackp = pctx->org_domain_from_fallback;
+	return DMARC_PARSE_OKAY;
+}
+
 /**************************************************************************
 ** OPENDMARC_GET_POLICY_TOKEN_USED -- Which policy was actually used
 **

--- a/libopendmarc/opendmarc_policy.c
+++ b/libopendmarc/opendmarc_policy.c
@@ -805,7 +805,13 @@ query_again:
 	tld_reply = opendmarc_get_tld(domain, tld, sizeof tld);
 	if (tld_reply != 0)
 		goto dns_failed;
-	if (strlen(tld) > 0)
+
+	/*
+	 * If the PSL identified an organizational domain distinct from the
+	 * queried domain, try exactly that domain and stop.  Per RFC 7489
+	 * §6.6.3 we look at one domain: the organizational domain.
+	 */
+	if (strlen(tld) > 0 && strcasecmp((char *)tld, (char *)domain) != 0)
 	{
 		pctx->organizational_domain = strdup(tld);
 
@@ -818,14 +824,60 @@ query_again2:
 		if (bp != NULL)
 			goto got_record;
 		/*
-		 * Was a CNAME was found that the resolver did
-		 * not follow on its own?
+		 * Was a CNAME found that the resolver did not follow on its own?
 		 */
 		if (bp == NULL && *buf != '\0')
 		{
 			(void) strlcpy(copy, buf, sizeof copy);
 			if (--loop_count != 0)
 				goto query_again2;
+		}
+		/* Organizational domain has no DMARC record; do not try further. */
+		goto dns_failed;
+	}
+
+	/*
+	 * No PSL was loaded, or the PSL could not identify an organizational
+	 * domain boundary (it returned the input domain unchanged).  Walk up
+	 * the label tree as a best-effort fallback, stopping before bare TLDs.
+	 * This is not strictly per RFC 7489 (which requires a PSL to determine
+	 * the organizational domain), but it handles the common case where no
+	 * PSL is configured and a parent domain has a DMARC record.
+	 * Configure PublicSuffixList in opendmarc.conf for RFC-compliant behavior.
+	 */
+	{
+		u_char *cur = (u_char *)domain;
+		u_char *dot;
+
+		while ((dot = (u_char *)strchr((char *)cur, '.')) != NULL)
+		{
+			cur = dot + 1;
+
+			/* Stop before bare TLDs (labels with no further dot). */
+			if (strchr((char *)cur, '.') == NULL)
+				break;
+
+			loop_count = DNS_MAX_RETRIES;
+			(void) strlcpy(copy, "_dmarc.", sizeof copy);
+			(void) strlcat(copy, cur, sizeof copy);
+query_again3:
+			(void) memset(buf, '\0', sizeof buf);
+			bp = dmarc_dns_get_record(copy, &dns_reply, buf, sizeof buf);
+			if (bp != NULL)
+			{
+				pctx->organizational_domain = strdup(cur);
+				pctx->org_domain_from_fallback = 1;
+				goto got_record;
+			}
+			/*
+			 * Was a CNAME found that the resolver did not follow on its own?
+			 */
+			if (bp == NULL && *buf != '\0')
+			{
+				(void) strlcpy(copy, buf, sizeof copy);
+				if (--loop_count != 0)
+					goto query_again3;
+			}
 		}
 	}
 dns_failed:

--- a/libopendmarc/tests/Makefile.am
+++ b/libopendmarc/tests/Makefile.am
@@ -10,7 +10,8 @@ check_PROGRAMS		 = test_tld \
 			   test_parse_to_buf \
 			   test_alignment \
 			   test_spf_parse \
-			   test_arcares
+			   test_arcares \
+			   test_subdomain_fallback
 if LIVE_TESTS
 #check_PROGRAMS           += test_dns_lookup
 #test_dns_lookup_SOURCES  = test_dns_lookup.c
@@ -45,6 +46,8 @@ test_arcares_SOURCES  = test_arcares.c \
 	$(top_srcdir)/opendmarc/opendmarc-ar.c
 test_arcares_CPPFLAGS = -I$(top_srcdir)/opendmarc -I.. -I../..
 test_arcares_LDADD    = $(LIBRESOLV)
+
+test_subdomain_fallback_SOURCES = test_subdomain_fallback.c
 
 TESTS = $(check_PROGRAMS)
 

--- a/libopendmarc/tests/test_subdomain_fallback.c
+++ b/libopendmarc/tests/test_subdomain_fallback.c
@@ -1,0 +1,262 @@
+/*
+** test_subdomain_fallback.c -- regression test for issue #54
+**
+** When a subdomain has no _dmarc record, opendmarc_policy_query_dmarc()
+** must fall back to the organizational/parent domain's DMARC record
+** per RFC 7489 §6.6.3.
+**
+** Before the fix, when no PublicSuffixList was configured, opendmarc_get_tld()
+** returned the queried domain unchanged.  The fallback then re-queried the
+** same _dmarc name, which also had no record, and the function returned
+** DMARC_DNS_ERROR_NO_RECORD regardless of whether a parent had a record.
+**
+** The fix adds a label-walking fallback for the no-PSL case, and keeps the
+** existing PSL-based single-lookup path for the case where a PSL is loaded.
+**
+** Distinct domain names are used for each test to avoid cross-contamination
+** of the global fake-DNS table (entries persist for the process lifetime).
+*/
+
+#include "../opendmarc_internal.h"
+#include "../dmarc.h"
+
+#define TESTFILE "testfiles/effective_tld_names.dat"
+
+#define CHECK(cond, msg)	\
+	do {			\
+		count++;	\
+		if (cond) {	\
+			pass++;	\
+		} else {	\
+			printf("\t%s(%d): %s: FAIL\n", __FILE__, __LINE__, msg); \
+			fails++;	\
+		}		\
+	} while (0)
+
+int
+main(int argc, char **argv)
+{
+	int pass = 0, fails = 0, count = 0;
+	DMARC_POLICY_T *pctx;
+	OPENDMARC_STATUS_T status;
+	int p;
+	u_char utilized[256];
+	char *srcdir;
+
+	srcdir = getenv("srcdir");
+	if (srcdir != NULL)
+	{
+		if (chdir(srcdir) != 0)
+		{
+			perror(srcdir);
+			return 1;
+		}
+	}
+
+	/*
+	 * Set up the fake DNS table.  Once any entry is added, dmarc_dns_get_record()
+	 * consults only this table for all lookups; names absent from the table
+	 * return NO_DATA (simulating "no record found").
+	 *
+	 * Use a distinct domain per test to avoid cross-contamination.
+	 */
+
+	/* Test domains and their fake records. */
+	opendmarc_dns_fake_record("_dmarc.parent1.example",
+	    "v=DMARC1; p=reject; rua=mailto:dmarc@parent1.example");
+	/* _dmarc.sub.parent1.example: absent from table → NO_DATA */
+
+	opendmarc_dns_fake_record("_dmarc.own-record.example",
+	    "v=DMARC1; p=quarantine");
+
+	opendmarc_dns_fake_record("_dmarc.parent3.example",
+	    "v=DMARC1; p=none; sp=reject");
+	/* _dmarc.a.b.parent3.example and _dmarc.b.parent3.example: absent → NO_DATA */
+
+	/* _dmarc.sub.nodmarc.example and _dmarc.nodmarc.example: absent → NO_DATA */
+
+	/* PSL test: bcx.com is recognized as registrable by the test TLD file. */
+	opendmarc_dns_fake_record("_dmarc.bcx.com",
+	    "v=DMARC1; p=reject");
+	/* _dmarc.sub.bcx.com: absent → NO_DATA */
+
+	/*
+	 * === Test 1 ===
+	 * No PSL.  Subdomain has no record; parent has p=reject.
+	 *
+	 * Before the fix: returned DMARC_DNS_ERROR_NO_RECORD.
+	 * After the fix:  label-walking finds _dmarc.parent1.example → DMARC_PARSE_OKAY.
+	 */
+	pctx = opendmarc_policy_connect_init((u_char *)"1.2.3.4", 0);
+	if (pctx == NULL) { fprintf(stderr, "connect_init failed\n"); return 1; }
+
+	(void) opendmarc_policy_store_from_domain(pctx, (u_char *)"sub.parent1.example");
+	status = opendmarc_policy_query_dmarc(pctx, (u_char *)"sub.parent1.example");
+
+	CHECK(status == DMARC_PARSE_OKAY,
+	    "no-PSL subdomain fallback: query should return DMARC_PARSE_OKAY");
+	if (status == DMARC_PARSE_OKAY)
+	{
+		opendmarc_policy_fetch_p(pctx, &p);
+		CHECK(p == DMARC_RECORD_P_REJECT,
+		    "no-PSL subdomain fallback: inherited p= should be reject");
+
+		(void) memset(utilized, '\0', sizeof utilized);
+		opendmarc_policy_fetch_utilized_domain(pctx, utilized, sizeof utilized);
+		CHECK(strcasecmp((char *)utilized, "parent1.example") == 0,
+		    "no-PSL subdomain fallback: utilized domain should be parent1.example");
+	}
+
+	pctx = opendmarc_policy_connect_shutdown(pctx);
+
+	/*
+	 * === Test 2 ===
+	 * Domain with its own DMARC record — no fallback should occur.
+	 */
+	pctx = opendmarc_policy_connect_init((u_char *)"1.2.3.4", 0);
+	if (pctx == NULL) { fprintf(stderr, "connect_init failed\n"); return 1; }
+
+	(void) opendmarc_policy_store_from_domain(pctx, (u_char *)"own-record.example");
+	status = opendmarc_policy_query_dmarc(pctx, (u_char *)"own-record.example");
+
+	CHECK(status == DMARC_PARSE_OKAY,
+	    "domain with own record: query should return DMARC_PARSE_OKAY");
+	if (status == DMARC_PARSE_OKAY)
+	{
+		opendmarc_policy_fetch_p(pctx, &p);
+		CHECK(p == DMARC_RECORD_P_QUARANTINE,
+		    "domain with own record: p= should be quarantine");
+	}
+
+	pctx = opendmarc_policy_connect_shutdown(pctx);
+
+	/*
+	 * === Test 3 ===
+	 * No PSL.  Deeply nested subdomain: a.b.parent3.example.
+	 * Neither _dmarc.b.parent3.example nor _dmarc.a.b.parent3.example exist.
+	 * Label walk should reach _dmarc.parent3.example (p=none, sp=reject).
+	 */
+	pctx = opendmarc_policy_connect_init((u_char *)"1.2.3.4", 0);
+	if (pctx == NULL) { fprintf(stderr, "connect_init failed\n"); return 1; }
+
+	(void) opendmarc_policy_store_from_domain(pctx, (u_char *)"a.b.parent3.example");
+	status = opendmarc_policy_query_dmarc(pctx, (u_char *)"a.b.parent3.example");
+
+	CHECK(status == DMARC_PARSE_OKAY,
+	    "no-PSL deeply nested subdomain: query should return DMARC_PARSE_OKAY");
+	if (status == DMARC_PARSE_OKAY)
+	{
+		opendmarc_policy_fetch_p(pctx, &p);
+		CHECK(p == DMARC_RECORD_P_NONE,
+		    "no-PSL deeply nested subdomain: p= from parent should be none");
+
+		(void) memset(utilized, '\0', sizeof utilized);
+		opendmarc_policy_fetch_utilized_domain(pctx, utilized, sizeof utilized);
+		CHECK(strcasecmp((char *)utilized, "parent3.example") == 0,
+		    "no-PSL deeply nested subdomain: utilized domain should be parent3.example");
+	}
+
+	pctx = opendmarc_policy_connect_shutdown(pctx);
+
+	/*
+	 * === Test 4 ===
+	 * No PSL.  No DMARC record at subdomain or any parent.
+	 * Should return DMARC_DNS_ERROR_NO_RECORD (graceful failure).
+	 */
+	pctx = opendmarc_policy_connect_init((u_char *)"1.2.3.4", 0);
+	if (pctx == NULL) { fprintf(stderr, "connect_init failed\n"); return 1; }
+
+	(void) opendmarc_policy_store_from_domain(pctx, (u_char *)"sub.nodmarc.example");
+	status = opendmarc_policy_query_dmarc(pctx, (u_char *)"sub.nodmarc.example");
+
+	CHECK(status == DMARC_DNS_ERROR_NO_RECORD,
+	    "no-PSL no record anywhere: should return DMARC_DNS_ERROR_NO_RECORD");
+
+	pctx = opendmarc_policy_connect_shutdown(pctx);
+
+	printf("Subdomain fallback (no PSL): pass=%d, fail=%d\n", pass, fails);
+
+	/*
+	 * === Tests 5-6: repeat key cases with PSL loaded ===
+	 *
+	 * With a PSL, opendmarc_get_tld() returns the correct organizational
+	 * domain (e.g. bcx.com for sub.bcx.com), so the existing PSL-based
+	 * code path is used rather than the new label-walking fallback.
+	 */
+	if (opendmarc_tld_read_file(TESTFILE, "//", "*.", "!") != 0)
+	{
+		printf("PSL tests: %s: could not read TLD file, skipping.\n", TESTFILE);
+	}
+	else
+	{
+		int psl_pass = 0, psl_fails = 0, psl_count = 0;
+
+#undef CHECK
+#define CHECK(cond, msg)	\
+		do {			\
+			psl_count++;	\
+			if (cond) {	\
+				psl_pass++;	\
+			} else {	\
+				printf("\t%s(%d): %s: FAIL\n", __FILE__, __LINE__, msg); \
+				psl_fails++;	\
+			}		\
+		} while (0)
+
+		/*
+		 * Test 5: PSL loaded; sub.bcx.com has no record, bcx.com has p=reject.
+		 * opendmarc_get_tld("sub.bcx.com") → "bcx.com" (different), so the
+		 * PSL path queries _dmarc.bcx.com and finds the record.
+		 */
+		pctx = opendmarc_policy_connect_init((u_char *)"1.2.3.4", 0);
+		if (pctx == NULL) { fprintf(stderr, "connect_init failed\n"); return 1; }
+
+		(void) opendmarc_policy_store_from_domain(pctx, (u_char *)"sub.bcx.com");
+		status = opendmarc_policy_query_dmarc(pctx, (u_char *)"sub.bcx.com");
+
+		CHECK(status == DMARC_PARSE_OKAY,
+		    "PSL subdomain fallback: query should return DMARC_PARSE_OKAY");
+		if (status == DMARC_PARSE_OKAY)
+		{
+			opendmarc_policy_fetch_p(pctx, &p);
+			CHECK(p == DMARC_RECORD_P_REJECT,
+			    "PSL subdomain fallback: inherited p= should be reject");
+
+			(void) memset(utilized, '\0', sizeof utilized);
+			opendmarc_policy_fetch_utilized_domain(pctx, utilized, sizeof utilized);
+			CHECK(strcasecmp((char *)utilized, "bcx.com") == 0,
+			    "PSL subdomain fallback: utilized domain should be bcx.com");
+		}
+
+		pctx = opendmarc_policy_connect_shutdown(pctx);
+
+		/*
+		 * Test 6: PSL loaded; domain with its own record — no fallback.
+		 */
+		pctx = opendmarc_policy_connect_init((u_char *)"1.2.3.4", 0);
+		if (pctx == NULL) { fprintf(stderr, "connect_init failed\n"); return 1; }
+
+		(void) opendmarc_policy_store_from_domain(pctx, (u_char *)"own-record.example");
+		status = opendmarc_policy_query_dmarc(pctx, (u_char *)"own-record.example");
+
+		CHECK(status == DMARC_PARSE_OKAY,
+		    "PSL domain with own record: query should return DMARC_PARSE_OKAY");
+		if (status == DMARC_PARSE_OKAY)
+		{
+			opendmarc_policy_fetch_p(pctx, &p);
+			CHECK(p == DMARC_RECORD_P_QUARANTINE,
+			    "PSL domain with own record: p= should be quarantine");
+		}
+
+		pctx = opendmarc_policy_connect_shutdown(pctx);
+
+		printf("Subdomain fallback (with PSL): pass=%d, fail=%d\n",
+		    psl_pass, psl_fails);
+
+		pass  += psl_pass;
+		fails += psl_fails;
+	}
+
+	printf("Subdomain fallback overall: pass=%d, fail=%d\n", pass, fails);
+	return fails;
+}

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -3137,6 +3137,22 @@ mlfi_eom(SMFICTX *ctx)
 	                                       pdomain, sizeof pdomain);
 	dmarcf_dstring_printf(dfc->mctx_histbuf, "pdomain %s\n", pdomain);
 
+	/*
+	 * Warn when the organizational domain was guessed by walking up the
+	 * label tree rather than determined via the public suffix list.
+	 * This means the result may not be RFC 7489-compliant.
+	 */
+	if (cc->cctx_dmarc->org_domain_from_fallback && conf->conf_dolog)
+	{
+		syslog(LOG_WARNING,
+		       "%s: no PublicSuffixList configured; guessed "
+		       "organizational domain \"%s\" for \"%s\" by walking "
+		       "up the label tree -- set PublicSuffixList in "
+		       "opendmarc.conf for RFC 7489-compliant behavior",
+		       dfc->mctx_jobid, pdomain,
+		       dfc->mctx_fromdomain);
+	}
+
 	policy = opendmarc_get_policy_to_enforce(cc->cctx_dmarc);
 	if (ostatus == DMARC_DNS_ERROR_NO_RECORD)
 		policy = DMARC_POLICY_ABSENT;

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -3142,15 +3142,19 @@ mlfi_eom(SMFICTX *ctx)
 	 * label tree rather than determined via the public suffix list.
 	 * This means the result may not be RFC 7489-compliant.
 	 */
-	if (cc->cctx_dmarc->org_domain_from_fallback && conf->conf_dolog)
 	{
-		syslog(LOG_WARNING,
-		       "%s: no PublicSuffixList configured; guessed "
-		       "organizational domain \"%s\" for \"%s\" by walking "
-		       "up the label tree -- set PublicSuffixList in "
-		       "opendmarc.conf for RFC 7489-compliant behavior",
-		       dfc->mctx_jobid, pdomain,
-		       dfc->mctx_fromdomain);
+		int fallback = 0;
+		(void) opendmarc_policy_fetch_org_domain_from_fallback(cc->cctx_dmarc, &fallback);
+		if (fallback && conf->conf_dolog)
+		{
+			syslog(LOG_WARNING,
+			       "%s: no PublicSuffixList configured; guessed "
+			       "organizational domain \"%s\" for \"%s\" by walking "
+			       "up the label tree -- set PublicSuffixList in "
+			       "opendmarc.conf for RFC 7489-compliant behavior",
+			       dfc->mctx_jobid, pdomain,
+			       dfc->mctx_fromdomain);
+		}
 	}
 
 	policy = opendmarc_get_policy_to_enforce(cc->cctx_dmarc);


### PR DESCRIPTION
## Summary

When a subdomain has no `_dmarc` record and no `PublicSuffixList` is configured, OpenDMARC was re-querying the same subdomain rather than walking up to the parent domain, resulting in `dmarc=none` even when the parent has a policy.

## Fix

Two-part fix in `opendmarc_policy.c`:

**PSL path** (RFC 7489-compliant): Add `strcasecmp` guard so the PSL result is only used when it identifies a *different* (parent) domain. When the PSL finds an org domain with no DMARC record, stop immediately rather than falling through.

**Label-walk fallback** (no PSL configured): When the PSL is absent or returns the input domain unchanged, walk up the label tree querying `_dmarc` at each level, stopping before bare TLDs. Not strictly RFC 7489-compliant (which requires a PSL), but handles the common case correctly. A `LOG_WARNING` is emitted via syslog to tell operators what happened and point them toward configuring `PublicSuffixList`.

Adds `org_domain_from_fallback` flag to `dmarc_policy_t` to track when the fallback path was used.

## Notes

- The label-walk fallback will be superseded by the DMARCbis (RFC 9989) DNS tree walk algorithm, which replaces PSL-based org domain discovery entirely. That work is planned before release; this fix is a meaningful improvement in the interim.
- Rebased onto current develop; conflict in `libopendmarc/tests/Makefile.am` resolved by including both the new `test_subdomain_fallback` and the existing `test_spf_parse`/`test_arcares` tests.

Fixes #54.