### PR TITLE
Add option to suppress reports to specific addresses to prevent RUA loops (openSUSE ticket208)

### DIFF
--- a/opendmarc/opendmarc-config.h
+++ b/opendmarc/opendmarc-config.h
@@ -40,6 +40,7 @@ struct configdef dmarcf_config[] =
 	{ "IgnoreAuthenticatedClients",	CONFIG_TYPE_BOOLEAN,	FALSE },
 	{ "IgnoreHosts",		CONFIG_TYPE_STRING,	FALSE },
 	{ "IgnoreMailFrom",		CONFIG_TYPE_STRING,	FALSE },
+	{ "IgnoreMailTo",		CONFIG_TYPE_STRING,	FALSE },
 	{ "MilterDebug",		CONFIG_TYPE_INTEGER,	FALSE },
 	{ "PidFile",			CONFIG_TYPE_STRING,	FALSE },
 	{ "PublicSuffixList",		CONFIG_TYPE_STRING,	FALSE },

--- a/opendmarc/opendmarc.8.in
+++ b/opendmarc/opendmarc.8.in
@@ -128,7 +128,11 @@ output.
 Print the version number and supported canonicalization and signature
 algorithms, and then exit without doing anything else.
 .SH SIGNALS
-Upon receiving SIGUSR1, if the filter was started with a configuration
+Upon receiving
+.B SIGHUP
+or
+.BR SIGUSR1 ,
+if the filter was started with a configuration
 file, it will be re-read and the new values used.  Note that any
 command line overrides provided at startup time will be lost when this is
 done.  Also, the following configuration file values (and their corresponding

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -3966,12 +3966,12 @@ struct smfiDesc smfilter =
 static void
 dmarcf_sighandler(int sig)
 {
-	if (sig == SIGINT || sig == SIGTERM || sig == SIGHUP)
+	if (sig == SIGINT || sig == SIGTERM)
 	{
 		diesig = sig;
 		die = TRUE;
 	}
-	else if (sig == SIGUSR1)
+	else if (sig == SIGHUP || sig == SIGUSR1)
 	{
 		if (conffile != NULL)
 			reload = TRUE;

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -194,6 +194,7 @@ struct dmarcf_config
 	char **			conf_ignoredomains;
 	struct list *		conf_domainwhitelist;
 	unsigned int		conf_domainwhitelisthashcount;
+	char **			conf_ignorereceivers;
 };
 
 /* LIST -- basic linked list of strings */
@@ -1380,6 +1381,11 @@ dmarcf_config_load(struct config *data, struct dmarcf_config *conf,
 		if (str != NULL)
 			dmarcf_mkarray(str, ",", &conf->conf_ignoredomains);
 
+		str = NULL;
+		(void) config_get(data, "IgnoreMailTo", &str, sizeof str);
+		if (str != NULL)
+			dmarcf_mkarray(str, ",", &conf->conf_ignorereceivers);
+
 		(void) config_get(data, "AuthservIDWithJobID",
 		                  &conf->conf_authservidwithjobid,
 		                  sizeof conf->conf_authservidwithjobid);
@@ -2307,6 +2313,7 @@ sfsistat
 mlfi_eom(SMFICTX *ctx)
 {
 	_Bool wspf = FALSE;
+	int skiphistory;
 	int c;
 	int pc;
 	int policy;
@@ -3771,7 +3778,34 @@ mlfi_eom(SMFICTX *ctx)
 	**  Record activity in the history file.
 	*/
 
-	if (conf->conf_historyfile != NULL &&
+	skiphistory = 0;
+	if (conf->conf_ignorereceivers != NULL)
+	{
+		struct dmarcf_header *to = dmarcf_findheader(dfc, "To", 0);
+		if (to != NULL)
+		{
+			char *val = to->hdr_value;
+			while (*val && !skiphistory)
+			{
+				memset(addrbuf, '\0', sizeof addrbuf);
+				strncpy(addrbuf, val, sizeof addrbuf - 1);
+				status = dmarcf_mail_parse(addrbuf, &user, &domain);
+				if (status == 0 && user != NULL && domain != NULL)
+				{
+					snprintf(replybuf, sizeof replybuf - 1, "%s@%s", user, domain);
+					if(dmarcf_match(replybuf, conf->conf_ignorereceivers, TRUE))
+					{
+						skiphistory = 1;
+					}
+				}
+				while(*val && *val != ',' && *val != ';')
+					++val;
+				if(*val)
+					++val;
+			}
+		}
+	}
+	if (!skiphistory && conf->conf_historyfile != NULL &&
 	    (conf->conf_recordall || ostatus != DMARC_DNS_ERROR_NO_RECORD))
 	{
 		FILE *f;

--- a/opendmarc/opendmarc.conf.5.in
+++ b/opendmarc/opendmarc.conf.5.in
@@ -232,6 +232,13 @@ against this list is case-insensitive.  The default is an empty list, meaning
 no mail is ignored.
 
 .TP
+.I IgnoreMailTo (string)
+Gives a list of mail addresses which aren't entered into the history file.
+This is useful to prevent exchanging single message reports.  The
+list should be comma-separated.  Matching against this list is
+case-insensitive.  The default is an empty list, meaning no mail is ignored.
+
+.TP
 .I MilterDebug (integer)
 Sets the debug level to be requested from the milter library.  The
 default is 0.

--- a/opendmarc/opendmarc.conf.sample
+++ b/opendmarc/opendmarc.conf.sample
@@ -268,6 +268,16 @@
 #
 # IgnoreMailFrom example.com
 
+##  IgnoreMailTo email[,...]
+##  	default (none)
+##
+##  Gives a list of mail addresses which aren't entered into the history file.
+##  This is useful to prevent exchanging mutual message reports.  The
+##  list should be comma-separated.  Matching against this list is
+##  case-insensitive.  The default is an empty list, meaning no mail is ignored.
+#
+# IgnoreMailTo dmarc-ruf@example.com
+
 ##  MilterDebug (integer)
 ##  	default 0
 ##


### PR DESCRIPTION
Ticket 208 - Endless loop of rua-mails
written by Dirk Stoecker
status: optional - enhancement
This patch adds a new option to OpenDMARC to ignore mail to a given email address. This can be used to prevent report loops.