### PR TITLE
Normalize domain names to lowercase on import (openSUSE ticket204)

### DIFF
--- a/opendmarc/opendmarc.8.in
+++ b/opendmarc/opendmarc.8.in
@@ -128,7 +128,11 @@ output.
 Print the version number and supported canonicalization and signature
 algorithms, and then exit without doing anything else.
 .SH SIGNALS
-Upon receiving SIGUSR1, if the filter was started with a configuration
+Upon receiving
+.B SIGHUP
+or
+.BR SIGUSR1 ,
+if the filter was started with a configuration
 file, it will be re-read and the new values used.  Note that any
 command line overrides provided at startup time will be lost when this is
 done.  Also, the following configuration file values (and their corresponding

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -3966,12 +3966,12 @@ struct smfiDesc smfilter =
 static void
 dmarcf_sighandler(int sig)
 {
-	if (sig == SIGINT || sig == SIGTERM || sig == SIGHUP)
+	if (sig == SIGINT || sig == SIGTERM)
 	{
 		diesig = sig;
 		die = TRUE;
 	}
-	else if (sig == SIGUSR1)
+	else if (sig == SIGHUP || sig == SIGUSR1)
 	{
 		if (conffile != NULL)
 			reload = TRUE;

--- a/reports/opendmarc-import.in
+++ b/reports/opendmarc-import.in
@@ -649,7 +649,7 @@ while (<$inputfh>)
 				}
 
 	  case "from"		{
-					$fdomain = $value;
+					$fdomain = lc($value);
 				}
 
 	  case "job"		{
@@ -691,7 +691,7 @@ while (<$inputfh>)
 				}
 
 	  case "mfrom"		{
-					$envdomain = $value;
+					$envdomain = lc($value);
 				}
 
 	  case "p"		{
@@ -703,7 +703,7 @@ while (<$inputfh>)
 				}
 
 	  case "pdomain"	{
-					$pdomain = $value;
+					$pdomain = lc($value);
 				}
 
 	  case "policy"		{


### PR DESCRIPTION
Ticket 204 - Domain database case depends on first entry written by Dirk Stoecker
status: recommended - bug fix
The first time a domain is received sets the case of the domain name. This patch fixes the import tool, so that domains are always entered in lower case. see #159