### PR TITLE
Add --skipdomains file option to opendmarc-reports (openSUSE ticket205)

### DIFF
--- a/reports/opendmarc-reports.8.in
+++ b/reports/opendmarc-reports.8.in
@@ -129,6 +129,16 @@ after sending.  Implied by
 Skips generating a report for the named domain.  Can be specified multiple
 times to skip multiple reporting domains.
 .TP
+.I --skipdomains=file
+Reads a list of domain names from
+.I file
+(one per line, comments introduced by
+.BR # )
+and skips generating reports for any domain in the list.  Equivalent to
+specifying
+.B --nodomain
+for each entry in the file.
+.TP
 .I --noupdate
 Suppresses marking the time of the transmission of the report in the database.
 Normally this would be done to prevent reports from being sent too close

--- a/reports/opendmarc-reports.in
+++ b/reports/opendmarc-reports.in
@@ -263,6 +263,7 @@ sub usage
 	print STDERR "\t--workdir=path     directory for temporary report files [.]\n";
 	print STDERR "\t -n                synonym for --test\n";
 	print STDERR "\t--nodomain=name    omit a report for named domain\n";
+	print STDERR "\t--skipdomains=file list of domains to omit a report for\n";
 	print STDERR "\t--noupdate         don't record report transmission\n";
 	print STDERR "\t--report-bcc       bcc address for aggregate reports\n";
 	print STDERR "\t--report-contact   contact address for report metadata (default: --report-email)\n";
@@ -352,6 +353,19 @@ if (-f $configfile)
 # set locale
 setlocale(LC_ALL, 'C');
 
+sub loadskipdomains
+{
+	die "Could not open domains file $_[1]" unless open FILE,"<",$_[1];
+	while (my $line = <FILE>)
+	{
+		$line =~ s/\s*#.*//;
+		$line =~ s/^\s+//;
+		$line =~ s/\s+$//;
+		push(@skipdomains, $line);
+	}
+	close FILE;
+}
+
 # parse command line arguments
 my $opt_retval = &Getopt::Long::GetOptions ('day!' => \$daybound,
                                             'db-dsn=s' => \$db_dsn,
@@ -369,6 +383,7 @@ my $opt_retval = &Getopt::Long::GetOptions ('day!' => \$daybound,
                                             'workdir=s' => \$workdir,
                                             'n|test' => \$testmode,
                                             'nodomain=s' => \@skipdomains,
+                                            'skipdomains=s' => \&loadskipdomains,
                                             'report-bcc=s' => \$repbcc,
                                             'report-contact=s' => \$repcontact,
                                             'report-email=s' => \$repemail,


### PR DESCRIPTION
Ticket 205 - Allow to block outgoing email
written by Dirk Stoecker
status: recommended - enhancement
Add new commandline argument '--skipdomains <filename>' to opendmarc-reports, to skip reporting for all domains noted in a file. See #159