### PR TITLE
Fix memory leak in opendmarc_tld_read_file (openSUSE ticket212)

### DIFF
--- a/libopendmarc/opendmarc_tld.c
+++ b/libopendmarc/opendmarc_tld.c
@@ -134,8 +134,11 @@ opendmarc_tld_read_file(char *path_fname, char *commentstring, char *drop, char 
 		return (errno == 0) ? ENOMEM : errno;
 
 	fp = fopen(path_fname, "r");
-	if (fp == NULL)
-		return errno;
+	if (fp == NULL) {
+		ret = errno;
+		opendmarc_hash_shutdown(hashp);
+		return ret;
+	}
 
 	errno = 0;
 	while (fgets((char *)buf, sizeof buf, fp) != NULL)

--- a/opendmarc/opendmarc.8.in
+++ b/opendmarc/opendmarc.8.in
@@ -128,7 +128,11 @@ output.
 Print the version number and supported canonicalization and signature
 algorithms, and then exit without doing anything else.
 .SH SIGNALS
-Upon receiving SIGUSR1, if the filter was started with a configuration
+Upon receiving
+.B SIGHUP
+or
+.BR SIGUSR1 ,
+if the filter was started with a configuration
 file, it will be re-read and the new values used.  Note that any
 command line overrides provided at startup time will be lost when this is
 done.  Also, the following configuration file values (and their corresponding

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -3966,12 +3966,12 @@ struct smfiDesc smfilter =
 static void
 dmarcf_sighandler(int sig)
 {
-	if (sig == SIGINT || sig == SIGTERM || sig == SIGHUP)
+	if (sig == SIGINT || sig == SIGTERM)
 	{
 		diesig = sig;
 		die = TRUE;
 	}
-	else if (sig == SIGUSR1)
+	else if (sig == SIGHUP || sig == SIGUSR1)
 	{
 		if (conffile != NULL)
 			reload = TRUE;


### PR DESCRIPTION
Ticket 212 - opendmarc_tld_read_file() Memory Leak reported by Frank J. Lhota, written by Juri Haberland status: needed - bug fix
This patch fixes a memory leak in opendmarc_tld_read_file(). See #159