### PR TITLE
Fix incorrect domain in policy_published in aggregate reports (openSUSE ticket207)

### DIFF
--- a/opendmarc/opendmarc.8.in
+++ b/opendmarc/opendmarc.8.in
@@ -128,7 +128,11 @@ output.
 Print the version number and supported canonicalization and signature
 algorithms, and then exit without doing anything else.
 .SH SIGNALS
-Upon receiving SIGUSR1, if the filter was started with a configuration
+Upon receiving
+.B SIGHUP
+or
+.BR SIGUSR1 ,
+if the filter was started with a configuration
 file, it will be re-read and the new values used.  Note that any
 command line overrides provided at startup time will be lost when this is
 done.  Also, the following configuration file values (and their corresponding

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -3966,12 +3966,12 @@ struct smfiDesc smfilter =
 static void
 dmarcf_sighandler(int sig)
 {
-	if (sig == SIGINT || sig == SIGTERM || sig == SIGHUP)
+	if (sig == SIGINT || sig == SIGTERM)
 	{
 		diesig = sig;
 		die = TRUE;
 	}
-	else if (sig == SIGUSR1)
+	else if (sig == SIGHUP || sig == SIGUSR1)
 	{
 		if (conffile != NULL)
 			reload = TRUE;

--- a/reports/opendmarc-reports.in
+++ b/reports/opendmarc-reports.in
@@ -65,6 +65,7 @@ my $domainset;
 my $forcedomain;
 my @skipdomains;
 
+my $poldomain;
 my $policy;
 my $spolicy;
 my $policystr;
@@ -447,7 +448,7 @@ foreach (@$domainset)
 		next;
 	}
 
-	$dbi_s = $dbi_h->prepare("SELECT repuri, adkim, aspf, policy, spolicy, pct, UNIX_TIMESTAMP(lastsent) FROM requests WHERE domain = ?");
+	$dbi_s = $dbi_h->prepare("SELECT repuri, adkim, aspf, requests.policy, spolicy, pct, UNIX_TIMESTAMP(lastsent), domains.name FROM requests JOIN messages ON messages.from_domain=requests.domain LEFT JOIN domains ON messages.policy_domain = domains.id WHERE domain = ? GROUP BY policy_domain");
 	if (!$dbi_s->execute($domainid))
 	{
 		print STDERR "$progname: can't get reporting URI for domain $domain: " . $dbi_h->errstr . "\n";
@@ -457,6 +458,7 @@ foreach (@$domainset)
 	}
 
 	undef $repuri;
+	$poldomain=$domain;
 
 	while ($dbi_a = $dbi_s->fetchrow_arrayref())
 	{
@@ -487,6 +489,10 @@ foreach (@$domainset)
 		if (defined($dbi_a->[6]))
 		{
 			$lastsent = $dbi_a->[6];
+		}
+		if (defined($dbi_a->[7]))
+		{
+			$poldomain = $dbi_a->[7];
 		}
 	}
 
@@ -570,7 +576,7 @@ foreach (@$domainset)
 	print $tmpout "    </report_metadata>\n";
 
 	print $tmpout "    <policy_published>\n";
-	print $tmpout "        <domain>$domain</domain>\n";
+	print $tmpout "        <domain>$poldomain</domain>\n";
 	print $tmpout "        <adkim>$adkimstr</adkim>\n";
 	print $tmpout "        <aspf>$aspfstr</aspf>\n";
 	print $tmpout "        <p>$policystr</p>\n";


### PR DESCRIPTION
Ticket 207 - Published Policy Domain in aggregate reports is incorrect. written by Eneas Ulir de Queiroz
status: needed - bug fix
Opendmarc-report uses the wrong domain in <policy_published>. This patch fixes it. See #159