### PR TITLE
Read HistoryFile path from opendmarc.conf in opendmarc-importstats (openSUSE ticket159)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -538,6 +538,7 @@ AC_CONFIG_FILES([ Makefile
 		reports/opendmarc-expire.8
 		reports/opendmarc-import
 		reports/opendmarc-import.8
+		reports/opendmarc-importstats
 		reports/opendmarc-importstats.8
 		reports/opendmarc-params
 		reports/opendmarc-params.8

--- a/opendmarc/opendmarc.8.in
+++ b/opendmarc/opendmarc.8.in
@@ -128,7 +128,11 @@ output.
 Print the version number and supported canonicalization and signature
 algorithms, and then exit without doing anything else.
 .SH SIGNALS
-Upon receiving SIGUSR1, if the filter was started with a configuration
+Upon receiving
+.B SIGHUP
+or
+.BR SIGUSR1 ,
+if the filter was started with a configuration
 file, it will be re-read and the new values used.  Note that any
 command line overrides provided at startup time will be lost when this is
 done.  Also, the following configuration file values (and their corresponding

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -3966,12 +3966,12 @@ struct smfiDesc smfilter =
 static void
 dmarcf_sighandler(int sig)
 {
-	if (sig == SIGINT || sig == SIGTERM || sig == SIGHUP)
+	if (sig == SIGINT || sig == SIGTERM)
 	{
 		diesig = sig;
 		die = TRUE;
 	}
-	else if (sig == SIGUSR1)
+	else if (sig == SIGHUP || sig == SIGUSR1)
 	{
 		if (conffile != NULL)
 			reload = TRUE;

--- a/reports/opendmarc-importstats.in
+++ b/reports/opendmarc-importstats.in
@@ -10,17 +10,18 @@
 ## ran the job.
 
 ## setup
-statsdb="/var/tmp/dmarc.dat"
+statsdb="`grep ^HistoryFile @sysconfdir@/opendmarc.conf | sed 's/^HistoryFile\s\+//'`"
+[ -z "$statsdb" ] && exit 0
 # OPENDMARC_PASSWORD="password"; export OPENDMARC_PASSWORD
 
-if [ -s $statsdb ]
+if [ -s "$statsdb" ]
 then
-	mv $statsdb ${statsdb}.OLD.$$
+	mv "$statsdb" "${statsdb}.OLD.$$"
 
-	if opendmarc-import < ${statsdb}.OLD.$$
+	if opendmarc-import < "${statsdb}.OLD.$$"
 	then
-		rm ${statsdb}.OLD.$$
+		rm "${statsdb}.OLD.$$"
 	else
-		ls -l ${statsdb}.OLD.$$
+		ls -l "${statsdb}.OLD.$$"
 	fi
 fi


### PR DESCRIPTION
Ticket 159 - opendmarc-importstats ignores value of HistoryFile written by Juri Haberland
status: needed - bug fix
The opendmarc-importstats script looks for the history file in a hard-coded place. This patch gets the location from the opendmarc.conf file. See #159