### PR TITLE
Add sender hostname to failure report body text (openSUSE ticket184)

### DIFF
--- a/opendmarc/opendmarc.8.in
+++ b/opendmarc/opendmarc.8.in
@@ -128,7 +128,11 @@ output.
 Print the version number and supported canonicalization and signature
 algorithms, and then exit without doing anything else.
 .SH SIGNALS
-Upon receiving SIGUSR1, if the filter was started with a configuration
+Upon receiving
+.B SIGHUP
+or
+.BR SIGUSR1 ,
+if the filter was started with a configuration
 file, it will be re-read and the new values used.  Note that any
 command line overrides provided at startup time will be lost when this is
 done.  Also, the following configuration file values (and their corresponding

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -3966,12 +3966,12 @@ struct smfiDesc smfilter =
 static void
 dmarcf_sighandler(int sig)
 {
-	if (sig == SIGINT || sig == SIGTERM || sig == SIGHUP)
+	if (sig == SIGINT || sig == SIGTERM)
 	{
 		diesig = sig;
 		die = TRUE;
 	}
-	else if (sig == SIGUSR1)
+	else if (sig == SIGHUP || sig == SIGUSR1)
 	{
 		if (conffile != NULL)
 			reload = TRUE;

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -3429,7 +3429,8 @@ mlfi_eom(SMFICTX *ctx)
 			                      "failure report for an email "
 			                      "message received from\n"
 			                      "%s [%s] on %s.\n\n",
-			                      cc->cctx_host, cc->cctx_ipstr, timebuf);
+			                      cc->cctx_host[0] != '\0' ? cc->cctx_host : cc->cctx_ipstr,
+			                      cc->cctx_ipstr, timebuf);
 
 			dmarcf_dstring_printf(dfc->mctx_afrf,
 			                      "--%s:%s\n"

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -3427,9 +3427,9 @@ mlfi_eom(SMFICTX *ctx)
 			dmarcf_dstring_printf(dfc->mctx_afrf,
 			                      "This is an authentication "
 			                      "failure report for an email "
-			                      "message received from IP\n"
-			                      "%s on %s.\n\n",
-			                      cc->cctx_ipstr, timebuf);
+			                      "message received from\n"
+			                      "%s [%s] on %s.\n\n",
+			                      cc->cctx_host, cc->cctx_ipstr, timebuf);
 
 			dmarcf_dstring_printf(dfc->mctx_afrf,
 			                      "--%s:%s\n"


### PR DESCRIPTION
Ticket 184 - report the hostname in failure reports written by Juri Haberland
status: optional - enhancement
This patch is similar to ticket #139 (add rDNS info to failure reports), but this one adds the hostname (rDNS) to the failure message, which is what people see first after opening a failure report. See #159