### PR TITLE
Fix MySQL strict mode issues and normalize timezone to UTC (openSUSE ticket193)

### DIFF
--- a/CHANGES-202605.md
+++ b/CHANGES-202605.md
@@ -66,12 +66,13 @@ Significant gaps between the generated aggregate report XML and RFC 7489 require
 - **Timezone off-by-one in `--day` mode**: In `--day` mode, the domain selection query compared timestamps without date truncation, causing domains to be selected or skipped based on wall-clock time within the day rather than calendar day boundaries. (#324, issue #210)
 - **`--skipdomains` file option for `opendmarc-reports`**: Adds `--skipdomains=file` as a file-based companion to `--nodomain`. The file contains one From: domain per line with `#` comments supported; reports for any listed domain are skipped. (#383; written by Dirk Stöcker for openSUSE)
 - **RFC 2822 date format in aggregate report body**: The `"generated at"` line in aggregate report email bodies previously used `localtime()`, producing a locale-dependent string with no timezone. Now uses `strftime("%a, %e %b %Y %H:%M:%S %z (%Z)", localtime())`, matching RFC 2822 day-month-year ordering and the format already used for the report's `Date:` header. (#388; written by Juri Haberland for openSUSE, submitted by Dirk Stöcker)
+- **UTC timezone enforced in `opendmarc-expire` and `db/schema.mysql`**: `opendmarc-expire` now issues `SET TIME_ZONE='+00:00'` immediately after connecting to the database, ensuring timestamp arithmetic is consistent regardless of the server's local timezone setting. `db/schema.mysql` includes the same statement for new installations. A `db/update-db-schema.mysql` migration script is provided to upgrade existing 1.4.2 databases. (#390; written by Juri Haberland for openSUSE, submitted by Dirk Stöcker)
 
 ---
 
 ## Schema changes
 
-The following `ALTER TABLE` statements are required for existing installations. `opendmarc-reports` and `opendmarc-import` print warnings at startup if the relevant columns are missing.
+The following `ALTER TABLE` statements are required for existing installations upgrading from 1.4.2. `opendmarc-reports` and `opendmarc-import` print warnings at startup if the relevant columns are missing. A convenience script covering all of these changes is provided at `db/update-db-schema.mysql`.
 
 ```sql
 -- Fix MySQL strict mode incompatibility (issue #289)

--- a/db/Makefile.am
+++ b/db/Makefile.am
@@ -1,3 +1,3 @@
 # Copyright (c) 2012, The Trusted Domain Project.  All rights reserved.
 
-dist_doc_DATA = README.schema schema.mysql
+dist_doc_DATA = README.schema schema.mysql README.update-db-schema.mysql update-db-schema.mysql

--- a/db/README.update-db-schema.mysql
+++ b/db/README.update-db-schema.mysql
@@ -1,0 +1,10 @@
+To upgrade an existing OpenDMARC 1.4.2 database to the current schema, run:
+
+  mysql -u <user> -p <database> --force < update-db-schema.mysql
+
+The --force flag causes the script to continue past "Duplicate column name"
+or "Duplicate key name" errors, which occur when a migration has already been
+partially applied.
+
+For a full description of each change and the reasoning behind it, see
+CHANGES-202605.md in the top-level source directory.

--- a/db/schema.mysql
+++ b/db/schema.mysql
@@ -5,6 +5,7 @@
 
 CREATE DATABASE IF NOT EXISTS opendmarc;
 USE opendmarc;
+SET TIME_ZONE='+00:00';
 
 -- A table for mapping domain names and their DMARC policies to IDs
 CREATE TABLE IF NOT EXISTS domains (

--- a/db/update-db-schema.mysql
+++ b/db/update-db-schema.mysql
@@ -1,0 +1,44 @@
+-- OpenDMARC database migration script: 1.4.2 -> next release
+--
+-- Upgrades an existing 1.4.2 database to the current schema.
+-- Run as:
+--
+--   mysql -u <user> -p <database> --force < update-db-schema.mysql
+--
+-- Some statements may produce "Duplicate column name" or "Duplicate key name"
+-- errors if your database was already partially migrated; these are harmless
+-- and --force causes the script to continue past them.
+
+USE opendmarc;
+SET TIME_ZONE='+00:00';
+
+-- Fix MySQL 5.7+ strict mode: requests.lastsent must allow NULL so that
+-- newly-seen domains (never reported) are represented as NULL rather than
+-- the sentinel '1970-01-01 00:00:00', which is not accepted in strict mode.
+ALTER TABLE requests MODIFY COLUMN lastsent TIMESTAMP NULL DEFAULT NULL;
+
+-- RFC 7489 §8.2: fo= (failure reporting options) bitmask.
+ALTER TABLE requests ADD COLUMN fo TINYINT NOT NULL DEFAULT '0' AFTER pct;
+
+-- Fix strict mode import failures for messages written by older opendmarc
+-- versions that omitted these fields from the history file.
+ALTER TABLE messages MODIFY COLUMN spf TINYINT NOT NULL DEFAULT '0';
+ALTER TABLE messages MODIFY COLUMN align_dkim TINYINT UNSIGNED NOT NULL DEFAULT '5';
+ALTER TABLE messages MODIFY COLUMN align_spf TINYINT UNSIGNED NOT NULL DEFAULT '5';
+ALTER TABLE messages MODIFY COLUMN sigcount TINYINT UNSIGNED NOT NULL DEFAULT '0';
+ALTER TABLE messages MODIFY COLUMN arc TINYINT UNSIGNED NOT NULL DEFAULT '0';
+ALTER TABLE messages MODIFY COLUMN arc_policy TINYINT UNSIGNED NOT NULL DEFAULT '1';
+
+-- RFC 7489 §8.2: spf_scope distinguishes mfrom vs. helo SPF evaluation.
+ALTER TABLE messages ADD COLUMN spf_scope TINYINT NOT NULL DEFAULT '-1' AFTER spf;
+
+-- VERP bounce tracking: suppressions table for persistent report address suppression.
+CREATE TABLE IF NOT EXISTS suppressions (
+	id INT NOT NULL AUTO_INCREMENT,
+	address VARCHAR(255) NOT NULL,
+	added TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	reason VARCHAR(255),
+
+	PRIMARY KEY(id),
+	UNIQUE KEY(address)
+);

--- a/reports/opendmarc-expire.in
+++ b/reports/opendmarc-expire.in
@@ -218,6 +218,17 @@ if ($verbose)
 	print STDERR "$progname: connected to database\n";
 }
 
+# switch to UTC to have a defined date behaviour
+$dbi_s = $dbi_h->prepare("SET TIME_ZONE='+00:00'");
+
+if (!$dbi_s->execute())
+{
+	print STDERR "$progname: failed to change to UTC: " . $dbi_h->errstr . "\n";
+	$dbi_s->finish;
+	$dbi_h->disconnect;
+	exit(1);
+}
+
 #
 # Expire messages
 #


### PR DESCRIPTION
Ticket 193 - SQL strict mode compatibility
reported by Michiel Hazelhof, written by Juri Haberland status: needed - bug fix
Since MySQL version 5.7 the strict mode is enabled by default. That makes opendmarc-import fail to import the history data for reporting as well as opendmarc-expire failes. This patch fixes it. See #159