### PR TITLE
Use consistent Subject line for DMARC failure reports (openSUSE z01)

### DIFF
--- a/opendmarc/opendmarc.8.in
+++ b/opendmarc/opendmarc.8.in
@@ -128,7 +128,11 @@ output.
 Print the version number and supported canonicalization and signature
 algorithms, and then exit without doing anything else.
 .SH SIGNALS
-Upon receiving SIGUSR1, if the filter was started with a configuration
+Upon receiving
+.B SIGHUP
+or
+.BR SIGUSR1 ,
+if the filter was started with a configuration
 file, it will be re-read and the new values used.  Note that any
 command line overrides provided at startup time will be lost when this is
 done.  Also, the following configuration file values (and their corresponding

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -3966,12 +3966,12 @@ struct smfiDesc smfilter =
 static void
 dmarcf_sighandler(int sig)
 {
-	if (sig == SIGINT || sig == SIGTERM || sig == SIGHUP)
+	if (sig == SIGINT || sig == SIGTERM)
 	{
 		diesig = sig;
 		die = TRUE;
 	}
-	else if (sig == SIGUSR1)
+	else if (sig == SIGHUP || sig == SIGUSR1)
 	{
 		if (conffile != NULL)
 			reload = TRUE;

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -3394,19 +3394,9 @@ mlfi_eom(SMFICTX *ctx)
 			dmarcf_dstring_printf(dfc->mctx_afrf, "Date: %s\n",
 			                      timebuf);
 
-			h = dmarcf_findheader(dfc, "subject", 0);
-			if (h == NULL)
-			{
-				dmarcf_dstring_printf(dfc->mctx_afrf,
-				                      "Subject: DMARC failure report for job %s\n",
-				                      dfc->mctx_jobid);
-			}
-			else
-			{
-				dmarcf_dstring_printf(dfc->mctx_afrf,
-				                      "Subject: FW: %s\n",
-				                      h->hdr_value);
-			}
+			dmarcf_dstring_printf(dfc->mctx_afrf,
+					      "Subject: DMARC failure report for %s received from %s\n",
+					      dfc->mctx_fromdomain, cc->cctx_host);
 
 			dmarcf_dstring_cat(dfc->mctx_afrf,
 			                   "MIME-Version: 1.0\n");

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -3396,7 +3396,8 @@ mlfi_eom(SMFICTX *ctx)
 
 			dmarcf_dstring_printf(dfc->mctx_afrf,
 					      "Subject: DMARC failure report for %s received from %s\n",
-					      dfc->mctx_fromdomain, cc->cctx_host);
+					      dfc->mctx_fromdomain,
+					      cc->cctx_host[0] != '\0' ? cc->cctx_host : cc->cctx_ipstr);
 
 			dmarcf_dstring_cat(dfc->mctx_afrf,
 			                   "MIME-Version: 1.0\n");


### PR DESCRIPTION
changeSubjectFailureReport_v2.patch
written by Juri Haberland
status: optional - enhancement
This is an optional patch that changes the Subject: line of a failure report. See #159