### PR TITLE
docs: clarify IgnoreMailTo applies to your own reporting addresses

### DIFF
--- a/opendmarc/opendmarc.conf.5.in
+++ b/opendmarc/opendmarc.conf.5.in
@@ -226,14 +226,18 @@ no mail is ignored.
 
 .TP
 .I IgnoreMailTo (string)
-Gives a comma-separated list of email addresses whose inbound messages are
-not recorded in the history file and therefore generate no aggregate reports.
-This is useful to prevent report loops: if your domain publishes a
+Gives a comma-separated list of your own email addresses to which inbound
+messages are not recorded in the history file and therefore generate no
+aggregate reports.  This is useful to prevent report loops: if your domain
+publishes a
 .I ruf=
-address that also receives mail, adding that address here prevents report
-messages addressed to it from being treated as reportable traffic.  Matching
-is case-insensitive.  The default is an empty list, meaning all mail is
-recorded normally.
+or
+.I rua=
+address that this filter also processes inbound mail for, DMARC report
+messages delivered to that address would themselves be evaluated and
+potentially trigger further reports.  Adding your own reporting address here
+breaks that loop.  Matching is case-insensitive.  The default is an empty
+list, meaning all inbound mail is recorded normally.
 
 .TP
 .I MilterDebug (integer)

--- a/opendmarc/opendmarc.conf.sample
+++ b/opendmarc/opendmarc.conf.sample
@@ -257,11 +257,12 @@
 ##  IgnoreMailTo email[,...]
 ##  	default (none)
 ##
-##  Gives a comma-separated list of email addresses whose inbound messages are
-##  not recorded in the history file and therefore generate no aggregate
-##  reports.  Useful to prevent report loops: add any ruf= or rua= address
-##  that your mail infrastructure also delivers to this list.  Matching is
-##  case-insensitive.
+##  Gives a comma-separated list of your own email addresses to which inbound
+##  messages are not recorded in the history file and therefore generate no
+##  aggregate reports.  Use this to prevent report loops: if this filter
+##  processes inbound mail for an address you publish as your own rua= or ruf=
+##  destination, DMARC reports arriving at that address would themselves be
+##  evaluated and could trigger further reports.  Matching is case-insensitive.
 #
 # IgnoreMailTo dmarc-reports@example.com
 


### PR DESCRIPTION
Follow-up to #393.

The original documentation said "if your domain publishes a ruf= address that also receives mail" — which is technically correct but buries the key point. The feature is specifically for when *this filter processes inbound mail* for an address you've published as your own `rua=` or `ruf=` destination. "Your own" does a lot of clarifying work that was missing.

Updated both the manpage and the sample config comment.