### PR TITLE
contrib: DMARCbis deployment tracking survey scripts

### DIFF
--- a/CHANGES-202605.md
+++ b/CHANGES-202605.md
@@ -163,6 +163,13 @@ CREATE TABLE IF NOT EXISTS suppressions (
 
 ---
 
+## DMARCbis deployment tracking
+
+- **`contrib/dmarc-pct-survey.pl`**: New script to query the Cisco Umbrella top-1M domain list for DMARC records, reporting `pct=` and `psd=` tag usage. Useful for tracking DMARCbis adoption in the wild. Output is TSV (defaulting to a dated file `dmarc-pct-survey-YYYY-MM-DD.tsv`) with a `run_date` column so successive runs can be appended and queried over time.
+- **`contrib/dmarc-psd-survey.pl`**: New script to query all entries in the Public Suffix List for DMARC records, reporting `psd=` tag adoption. Tracks which TLDs and PSDs have published DMARC records and whether they declare `psd=y`, indicating readiness for RFC 9989 PSD DMARC. Handles wildcard PSL entries (`*.foo` → queries the parent), exception entries (`!foo.bar` → queries as-is), and separates ICANN from private domain sections (`--icann-only` to restrict). Output is TSV (defaulting to `dmarc-psd-survey-YYYY-MM-DD.tsv`) with a `run_date` column for longitudinal tracking.
+
+---
+
 ## CI
 
 - **GitHub Actions CI workflow added**: Linux build and test on Ubuntu, running on push and pull request to `develop`. (#330)

--- a/contrib/dmarc-pct-survey.pl
+++ b/contrib/dmarc-pct-survey.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/local/bin/perl
 use strict;
 use warnings;
 use Net::DNS;

--- a/contrib/dmarc-pct-survey.pl
+++ b/contrib/dmarc-pct-survey.pl
@@ -4,27 +4,37 @@ use warnings;
 use Net::DNS;
 use IO::Select;
 use Getopt::Long;
+use POSIX qw(strftime);
 
 # Query Umbrella top-1M domains for DMARC records, reporting pct= and psd= usage.
 #
-# Output (STDOUT): TSV - domain, pct_value, psd_value, full_record
+# Output (--output or STDOUT): TSV - run_date, domain, pct_value, psd_value, full_record
+#   run_date:  ISO 8601 date of this run (YYYY-MM-DD), for multi-run aggregation
 #   pct_value: numeric value if present, "-" if absent
 #   psd_value: "y", "n", or "-" if absent
 # Progress/stats (STDERR): running count + final summary
 
-my $concurrency = 500;
-my $timeout     = 5;
-my $infile      = 'top-1m.csv';
-my $max_domains = 0;  # 0 = unlimited
-my $nameserver;       # undef = system default
+my $concurrency  = 500;
+my $timeout      = 5;
+my $infile       = 'top-1m.csv';
+my $max_domains  = 0;     # 0 = unlimited
+my $nameserver;           # undef = system default
+my $outfile;              # undef = STDOUT
 
 GetOptions(
     'concurrency=i' => \$concurrency,
     'timeout=i'     => \$timeout,
     'input=s'       => \$infile,
+    'output=s'      => \$outfile,
     'max=i'         => \$max_domains,
     'nameserver=s'  => \$nameserver,
-) or die "Usage: $0 [--input FILE] [--concurrency N] [--timeout N] [--max N] [--nameserver IP]\n";
+) or die "Usage: $0 [--input FILE] [--output FILE] [--concurrency N] [--timeout N] [--max N] [--nameserver IP]\n";
+
+my $run_date = strftime('%Y-%m-%d', localtime);
+
+if (!defined($outfile)) {
+    $outfile = sprintf('dmarc-pct-survey-%s.tsv', $run_date);
+}
 
 my $resolver = Net::DNS::Resolver->new(
     udp_timeout => $timeout,
@@ -34,7 +44,8 @@ my $resolver = Net::DNS::Resolver->new(
     ($nameserver ? (nameservers => [$nameserver]) : ()),
 );
 
-open(my $fh, '<', $infile) or die "Cannot open $infile: $!\n";
+open(my $fh,  '<', $infile)  or die "Cannot open $infile: $!\n";
+open(my $out, '>', $outfile) or die "Cannot open $outfile: $!\n";
 
 # Stats
 my $n_queued   = 0;
@@ -103,16 +114,15 @@ sub harvest {
                 $n_psd_n++ if $psd eq 'n';
             }
 
-            print join("\t", $domain, $pct, $psd, $txt), "\n";
+            print $out join("\t", $run_date, $domain, $pct, $psd, $txt), "\n";
             last;  # only evaluate first v=DMARC1 record
         }
     }
 }
 
-# Print TSV header to STDOUT
-print join("\t", "domain", "pct", "psd", "record"), "\n";
+print $out join("\t", "run_date", "domain", "pct", "psd", "record"), "\n";
 
-print STDERR "Reading $infile, concurrency=$concurrency, timeout=${timeout}s\n";
+print STDERR "Reading $infile, writing $outfile, concurrency=$concurrency, timeout=${timeout}s\n";
 
 while (my $line = <$fh>) {
     chomp $line;
@@ -154,7 +164,9 @@ while (%inflight) {
     }
 }
 
-printf STDERR "\nDone.\n";
+close($out);
+
+printf STDERR "\nDone. Output written to %s\n", $outfile;
 printf STDERR "  Domains queried : %d\n", $n_done;
 printf STDERR "  Errors          : %d\n", $n_errors;
 printf STDERR "  Have DMARC      : %d (%.1f%%)\n", $n_dmarc, $n_done ? 100*$n_dmarc/$n_done : 0;

--- a/contrib/dmarc-psd-survey.pl
+++ b/contrib/dmarc-psd-survey.pl
@@ -1,0 +1,206 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Net::DNS;
+use IO::Select;
+use Getopt::Long;
+use POSIX qw(strftime);
+
+# Query Public Suffix List entries for DMARC records, reporting psd= adoption.
+# Tracks which public suffixes have published DMARC records and whether they
+# include psd=y, indicating readiness for DMARCbis PSD DMARC.
+#
+# Input: public_suffix_list.dat from https://publicsuffix.org/list/
+#
+# Output (--output or dated file): TSV - run_date, suffix, section, wildcard, exception, psd, record
+#   run_date:  ISO 8601 date of this run (YYYY-MM-DD), for multi-run aggregation
+#   section:   "icann" or "private"
+#   wildcard:  1 if the PSL entry was a wildcard (*.foo); suffix is the parent queried
+#   exception: 1 if the PSL entry was an exception (!foo.bar)
+#   psd:       "y", "n", or "-" if absent
+#   record:    full DMARC TXT record
+# Progress/stats (STDERR): running count + final summary
+
+my $concurrency = 200;
+my $timeout     = 5;
+my $infile      = 'public_suffix_list.dat';
+my $max_entries = 0;   # 0 = unlimited
+my $nameserver;        # undef = system default
+my $icann_only  = 0;   # if set, skip private domains section
+my $outfile;           # undef = use dated default
+
+GetOptions(
+    'concurrency=i' => \$concurrency,
+    'timeout=i'     => \$timeout,
+    'input=s'       => \$infile,
+    'output=s'      => \$outfile,
+    'max=i'         => \$max_entries,
+    'nameserver=s'  => \$nameserver,
+    'icann-only!'   => \$icann_only,
+) or die "Usage: $0 [--input FILE] [--output FILE] [--concurrency N] [--timeout N] [--max N] [--nameserver IP] [--icann-only]\n";
+
+my $run_date = strftime('%Y-%m-%d', localtime);
+
+if (!defined($outfile)) {
+    $outfile = sprintf('dmarc-psd-survey-%s.tsv', $run_date);
+}
+
+my $resolver = Net::DNS::Resolver->new(
+    udp_timeout => $timeout,
+    tcp_timeout => $timeout,
+    retrans     => 1,
+    retry       => 1,
+    ($nameserver ? (nameservers => [$nameserver]) : ()),
+);
+
+open(my $fh,  '<', $infile)  or die "Cannot open $infile: $!\n";
+open(my $out, '>', $outfile) or die "Cannot open $outfile: $!\n";
+
+# Stats
+my $n_queued    = 0;
+my $n_done      = 0;
+my $n_dmarc     = 0;  # has v=DMARC1 record
+my $n_psd       = 0;  # has psd= in record
+my $n_psd_y     = 0;  # has psd=y
+my $n_psd_n     = 0;  # has psd=n
+my $n_errors    = 0;
+
+# In-flight: socket => [ suffix, section, wildcard, exception ]
+my %inflight;
+my $sel = IO::Select->new;
+
+my $progress_interval = 500;
+my $next_progress     = $progress_interval;
+
+sub dispatch {
+    my ($suffix, $section, $wildcard, $exception) = @_;
+    my $qname  = "_dmarc.$suffix";
+    my $socket = $resolver->bgsend($qname, 'TXT');
+    unless ($socket) {
+        $n_errors++;
+        $n_done++;
+        return;
+    }
+    $inflight{$socket} = [ $suffix, $section, $wildcard, $exception ];
+    $sel->add($socket);
+    $n_queued++;
+}
+
+sub harvest {
+    my ($block) = @_;
+    my @ready = $block ? $sel->can_read($timeout) : $sel->can_read(0);
+    for my $sock (@ready) {
+        my $meta = delete $inflight{$sock};
+        $sel->remove($sock);
+        $n_done++;
+
+        my ($suffix, $section, $wildcard, $exception) = @$meta;
+
+        my $pkt = eval { $resolver->bgread($sock) };
+        unless ($pkt) {
+            $n_errors++;
+            next;
+        }
+
+        my $rcode = $pkt->header->rcode;
+        next if $rcode eq 'NXDOMAIN';
+        next if $rcode eq 'NOERROR' && !($pkt->answer);
+
+        for my $rr ($pkt->answer) {
+            next unless $rr->type eq 'TXT';
+            my $txt = join('', $rr->txtdata);
+            next unless $txt =~ /^v=DMARC1\b/i;
+
+            $n_dmarc++;
+
+            my $psd = ($txt =~ /\bpsd=([yn])/i) ? lc($1) : '-';
+
+            if ($psd ne '-') {
+                $n_psd++;
+                $n_psd_y++ if $psd eq 'y';
+                $n_psd_n++ if $psd eq 'n';
+            }
+
+            print $out join("\t", $run_date, $suffix, $section, $wildcard, $exception, $psd, $txt), "\n";
+            last;  # only evaluate first v=DMARC1 record
+        }
+    }
+}
+
+print $out join("\t", "run_date", "suffix", "section", "wildcard", "exception", "psd", "record"), "\n";
+
+my $section    = "icann";
+my $in_private = 0;
+
+print STDERR "Reading $infile, writing $outfile, concurrency=$concurrency, timeout=${timeout}s\n";
+
+while (my $line = <$fh>) {
+    chomp $line;
+
+    # Track section
+    if ($line =~ /===BEGIN PRIVATE DOMAINS===/) {
+        $in_private = 1;
+        $section = "private";
+        next;
+    }
+    if ($line =~ /===END PRIVATE DOMAINS===/) {
+        $in_private = 0;
+        next;
+    }
+
+    next if $icann_only && $in_private;
+
+    # Skip comments and blank lines
+    next if $line =~ /^\/\//;
+    next unless $line =~ /\S/;
+
+    my ($wildcard, $exception) = (0, 0);
+    my $entry = $line;
+    $entry =~ s/^\s+|\s+$//g;
+
+    if ($entry =~ s/^\*\.//) {
+        # Wildcard entry: *.foo.bar — query the parent (foo.bar)
+        $wildcard = 1;
+    } elsif ($entry =~ s/^!//) {
+        # Exception entry: !foo.bar — foo.bar is itself a PSD
+        $exception = 1;
+    }
+
+    next unless $entry =~ /\S/;
+
+    dispatch($entry, $section, $wildcard, $exception);
+
+    while (scalar(keys %inflight) >= $concurrency) {
+        harvest(1);
+    }
+    harvest(0);
+
+    if ($n_done >= $next_progress) {
+        printf STDERR "  %d done, %d in-flight, %d dmarc, %d psd=\n",
+            $n_done, scalar(keys %inflight), $n_dmarc, $n_psd;
+        $next_progress += $progress_interval;
+    }
+
+    last if $max_entries && $n_queued >= $max_entries;
+}
+
+close($fh);
+
+while (%inflight) {
+    harvest(1);
+    if ($n_done >= $next_progress) {
+        printf STDERR "  %d done, %d in-flight, %d dmarc, %d psd=\n",
+            $n_done, scalar(keys %inflight), $n_dmarc, $n_psd;
+        $next_progress += $progress_interval;
+    }
+}
+
+close($out);
+
+printf STDERR "\nDone. Output written to %s\n", $outfile;
+printf STDERR "  Suffixes queried : %d\n",                                                $n_done;
+printf STDERR "  Errors           : %d\n",                                                $n_errors;
+printf STDERR "  Have DMARC       : %d (%.1f%%)\n",          $n_dmarc, $n_done   ? 100*$n_dmarc/$n_done   : 0;
+printf STDERR "  Have psd=        : %d (%.1f%% of DMARC)\n", $n_psd,   $n_dmarc  ? 100*$n_psd/$n_dmarc    : 0;
+printf STDERR "    psd=y          : %d\n",                                                $n_psd_y;
+printf STDERR "    psd=n          : %d\n",                                                $n_psd_n;

--- a/contrib/dmarc-psd-survey.pl
+++ b/contrib/dmarc-psd-survey.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/local/bin/perl
 use strict;
 use warnings;
 use Net::DNS;


### PR DESCRIPTION
## Summary

- Adds `contrib/dmarc-pct-survey.pl`: queries the Cisco Umbrella top-1M domain list for DMARC records, reporting `pct=` and `psd=` tag usage
- Adds `contrib/dmarc-psd-survey.pl`: queries all Public Suffix List entries for DMARC records, reporting `psd=` adoption across TLDs and PSDs
- Both scripts write dated TSV output with a `run_date` column for longitudinal tracking over time
- Updates `dmarc-pct-survey.pl` to use `--output` flag and dated default filename (previously always wrote to STDOUT)

## Test plan

- [ ] Run `dmarc-pct-survey.pl --max 100` against a small slice of the Umbrella list and verify TSV output with `run_date` column
- [ ] Run `dmarc-psd-survey.pl --max 50 --icann-only` against a PSL file and verify wildcard/exception handling in output
- [ ] Confirm dated output filenames are generated correctly when `--output` is omitted