### PR TITLE
contrib: convert IDN labels to punycode in dmarc-psd-survey.pl

### DIFF
--- a/contrib/dmarc-psd-survey.pl
+++ b/contrib/dmarc-psd-survey.pl
@@ -6,6 +6,8 @@ use IO::Select;
 use Getopt::Long;
 use POSIX qw(strftime);
 use LWP::Simple qw(getstore);
+use URI::_idna;
+use Encode qw(encode decode);
 
 # Query Public Suffix List entries for DMARC records, reporting psd= adoption.
 # Tracks which public suffixes have published DMARC records and whether they
@@ -65,7 +67,7 @@ my $resolver = Net::DNS::Resolver->new(
     ($nameserver ? (nameservers => [$nameserver]) : ()),
 );
 
-open(my $fh,  '<', $infile)  or die "Cannot open $infile: $!\n";
+open(my $fh,  '<:encoding(UTF-8)', $infile)  or die "Cannot open $infile: $!\n";
 open(my $out, '>', $outfile) or die "Cannot open $outfile: $!\n";
 
 # Stats
@@ -179,6 +181,20 @@ while (my $line = <$fh>) {
     }
 
     next unless $entry =~ /\S/;
+
+    # Convert IDN labels to punycode if needed
+    if ($entry =~ /[^\x00-\x7F]/) {
+        my $ace = eval {
+            join('.', map {
+                /[^\x00-\x7F]/ ? URI::_idna::encode(decode('UTF-8', $_)) : $_
+            } split(/\./, $entry));
+        };
+        if ($@ || !defined($ace)) {
+            printf STDERR "  skipping non-convertible IDN entry: %s\n", $entry;
+            next;
+        }
+        $entry = $ace;
+    }
 
     dispatch($entry, $section, $wildcard, $exception);
 


### PR DESCRIPTION
## Summary

- PSL entries with non-ASCII (IDN) labels are now converted to punycode before the DNS query, fixing "label too long" errors from Net::DNS
- Uses `URI::_idna` (part of the URI package) for label encoding, applied per-label across the full domain
- PSL file is now opened with UTF-8 encoding
- Entries that fail conversion are skipped with a stderr notice

Follow-up to #398.

## Test plan

- [ ] Run against a fresh PSL; verify no "label too long" errors
- [ ] Confirm IDN entries (e.g. `日本`) appear as punycode in output