### PR TITLE
again allow to block domains, not only mail domains

### DIFF
--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -916,7 +916,7 @@ dmarcf_checkemail(const char *addr, struct list *list)
 
 	/* domain-only match */
 	at = strchr(addr, '@');
-	if (at != NULL && dmarcf_checklist(at + 1, list))
+	if (at != NULL && dmarcf_checklist(at, list))
 		return TRUE;
 
 	return FALSE;

--- a/opendmarc/opendmarc.conf.5.in
+++ b/opendmarc/opendmarc.conf.5.in
@@ -253,8 +253,8 @@ should never be delivered, regardless of what the DMARC policy record
 requests.  Each line contains one entry; lines beginning with
 .RB ` # '
 are treated as comments.  An entry may be a full email address
-(e.g. "reports@gmail.com") or a bare domain (e.g. "gmail.com"), in which
-case all addresses at that domain are suppressed.  Matching is
+(e.g. "reports@gmail.com"), a bare mail domain (e.g. "@gmail.com"), in which
+case all addresses at that domain are suppressed or a bare domain.  Matching is
 case-insensitive.  The same file is honoured by
 .IR opendmarc-reports (8)
 for aggregate report delivery suppression.  The default is unset, meaning

--- a/reports/opendmarc-reports.in
+++ b/reports/opendmarc-reports.in
@@ -506,7 +506,14 @@ if (defined($noreports_file))
 		s/#.*//;
 		s/^\s+|\s+$//g;
 		next unless length;
-		$noreports{lc($_)} = 1;
+		if($_ =~ /@/)
+		{
+			$noreports{lc($_)} = 1;
+		}
+		else
+		{
+			push(@skipdomains, lc($_));
+		}
 	}
 	close($nrf);
 }
@@ -1448,7 +1455,7 @@ foreach (@$domainset)
 			my $dest_lc = lc($repdest);
 			my ($dest_user, $dest_domain) = split(/\@/, $dest_lc, 2);
 			if ($noreports{$dest_lc} ||
-			    (defined($dest_domain) && $noreports{$dest_domain}))
+			    (defined($dest_domain) && $noreports{"@$dest_domain"}))
 			{
 				print STDERR "$progname: skipping $domain report to $repdest (NoReportsList)\n"
 					if $verbose;


### PR DESCRIPTION
This change takes the noreports file into account, but makes it clearer what exactly it blocks. Mails, Mail domains or domains. See also comment at #394

Also always having a @ in mail domains makes it clearer what is actually meant.

This change doesn't add the blocking of domains (not mail domains) in opendmarc.c. Probably easy, but I didn't find that when searching.