### PR TITLE
fix: implement @-sigil semantics for NoReportsList

### DIFF
--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -916,7 +916,7 @@ dmarcf_checkemail(const char *addr, struct list *list)
 
 	/* domain-only match */
 	at = strchr(addr, '@');
-	if (at != NULL && dmarcf_checklist(at + 1, list))
+	if (at != NULL && dmarcf_checklist(at, list))
 		return TRUE;
 
 	return FALSE;

--- a/opendmarc/opendmarc.conf.5.in
+++ b/opendmarc/opendmarc.conf.5.in
@@ -246,16 +246,34 @@ highest useful value.  The default is 0.
 
 .TP
 .I NoReportsList (string)
-Specifies the path to a file containing email addresses and/or domains to
-which failure reports (
-.IR ruf= )
-should never be delivered, regardless of what the DMARC policy record
-requests.  Each line contains one entry; lines beginning with
+Specifies the path to a file containing email addresses and/or domains for
+which report delivery should be suppressed.  Each line contains one entry;
+lines beginning with
 .RB ` # '
-are treated as comments.  An entry may be a full email address
-(e.g. "reports@gmail.com") or a bare domain (e.g. "gmail.com"), in which
-case all addresses at that domain are suppressed.  Matching is
-case-insensitive.  The same file is honoured by
+are treated as comments.  Three entry formats are recognised:
+.RS
+.TP
+.I user@example.com
+Suppresses delivery to that specific address.
+.TP
+.I @example.com
+Suppresses delivery to any address at that mail domain (the
+.RB ` @ '
+sigil distinguishes this from a sending-domain entry below).
+.TP
+.I example.com
+Suppresses aggregate reports for that sending domain (i.e. domains whose
+.I _dmarc
+record is being evaluated), equivalent to passing the domain to
+.BR --skipdomains (8)
+in
+.IR opendmarc-reports .
+This form has no effect on failure report
+.RI ( ruf= )
+suppression in the milter itself.
+.RE
+.P
+Matching is case-insensitive.  The same file is read by
 .IR opendmarc-reports (8)
 for aggregate report delivery suppression.  The default is unset, meaning
 all requested report destinations are used.

--- a/reports/opendmarc-reports.8.in
+++ b/reports/opendmarc-reports.8.in
@@ -137,7 +137,11 @@ Reads a list of domain names from
 and skips generating reports for any domain in the list.  Equivalent to
 specifying
 .B --nodomain
-for each entry in the file.
+for each entry in the file.  Bare domain entries in the
+.B NoReportsList
+file (see
+.IR opendmarc.conf (5))
+are automatically applied as if passed via this option.
 .TP
 .I --noupdate
 Suppresses marking the time of the transmission of the report in the database.

--- a/reports/opendmarc-reports.in
+++ b/reports/opendmarc-reports.in
@@ -506,7 +506,14 @@ if (defined($noreports_file))
 		s/#.*//;
 		s/^\s+|\s+$//g;
 		next unless length;
-		$noreports{lc($_)} = 1;
+		if($_ =~ /@/)
+		{
+			$noreports{lc($_)} = 1;
+		}
+		else
+		{
+			push(@skipdomains, lc($_));
+		}
 	}
 	close($nrf);
 }
@@ -1448,7 +1455,7 @@ foreach (@$domainset)
 			my $dest_lc = lc($repdest);
 			my ($dest_user, $dest_domain) = split(/\@/, $dest_lc, 2);
 			if ($noreports{$dest_lc} ||
-			    (defined($dest_domain) && $noreports{$dest_domain}))
+			    (defined($dest_domain) && $noreports{"@$dest_domain"}))
 			{
 				print STDERR "$progname: skipping $domain report to $repdest (NoReportsList)\n"
 					if $verbose;


### PR DESCRIPTION
## Summary

Implements three-way semantics for `NoReportsList` entries (patch by Dirk Stöcker, PR #403):

- `user@example.com` — suppress reports to that specific address
- `@example.com` — suppress reports to any address at that mail domain
- `example.com` — suppress reports for that sending domain (routed to existing `@skipdomains` in `opendmarc-reports`)

Code changes only; manpage documentation to follow separately.

## Changes

- `opendmarc.c`: `dmarcf_checkemail()` now matches `@domain` entries (with sigil) for domain-level suppression
- `opendmarc-reports.in`: entries with `@` go into `%noreports`; bare domain entries are pushed onto `@skipdomains`

## Test plan

- [ ] `user@example.com` entry suppresses delivery to that address only
- [ ] `@example.com` entry suppresses delivery to all addresses at example.com
- [ ] `example.com` entry skips aggregate reports for that sending domain