### PR TITLE
reports: use basename for report attachment filename

### DIFF
--- a/reports/opendmarc-reports.in
+++ b/reports/opendmarc-reports.in
@@ -1524,7 +1524,7 @@ foreach (@$domainset)
 			$mailout .= "\n";
 			$mailout .= "--$boundary\n";
 			$mailout .= "Content-Type: application/gzip\n";
-			$mailout .= "Content-Disposition: attachment; filename=\"$gzipfile\"\n";
+			$mailout .= "Content-Disposition: attachment; filename=\"" . basename($gzipfile) . "\"\n";
 			$mailout .= "Content-Transfer-Encoding: base64\n";
 			$mailout .= "\n";
 


### PR DESCRIPTION
The attachment `Content-Disposition` header was using the full spool file path as the filename, so recipients would receive attachments named like:

```
_var_db_opendmarc_reporter.example!domain.example!begin!end.xml.gz
```

instead of the RFC 7489 section 7.2 compliant:

```
reporter.example!domain.example!begin!end.xml.gz
```

`\$gzipfile` is the full path (`\$workdir . "/" . \$repdom . "!" . \$domain . ...`). `File::Basename` is already imported at the top of the script; this fix wraps the filename in `basename()`.