### PR TITLE
ci: add macOS build and test job (#407)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           brew install \
             autoconf automake libtool pkg-config \
-            openssl libmilter \
+            openssl sendmail \
             lua \
             cpanminus
           cpanm --notest DBI LWP IO::Compress JSON Net::DNS
@@ -85,8 +85,8 @@ jobs:
           autoreconf -fvi
           ./configure \
             CFLAGS='-g -O2 -Wno-pointer-sign' \
-            CPPFLAGS="-I$(brew --prefix openssl)/include -I$(brew --prefix libmilter)/include" \
-            LDFLAGS="-L$(brew --prefix openssl)/lib -L$(brew --prefix libmilter)/lib"
+            CPPFLAGS="-I$(brew --prefix openssl)/include -I$(brew --prefix sendmail)/include" \
+            LDFLAGS="-L$(brew --prefix openssl)/lib -L$(brew --prefix sendmail)/lib"
           make -j$(sysctl -n hw.logicalcpu)
           sudo make install
 
@@ -97,8 +97,8 @@ jobs:
         run: |
           ./configure --enable-live-tests \
             CFLAGS='-g -O2 -Wno-pointer-sign' \
-            CPPFLAGS="-I$(brew --prefix openssl)/include -I$(brew --prefix libmilter)/include" \
-            LDFLAGS="-L$(brew --prefix openssl)/lib -L$(brew --prefix libmilter)/lib"
+            CPPFLAGS="-I$(brew --prefix openssl)/include -I$(brew --prefix sendmail)/include" \
+            LDFLAGS="-L$(brew --prefix openssl)/lib -L$(brew --prefix sendmail)/lib"
 
       - name: Build
         run: make -j$(sysctl -n hw.logicalcpu)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,10 +80,12 @@ jobs:
 
       - name: Build and install libmilter from source
         run: |
-          SENDMAIL_VER=8.18.1
+          SENDMAIL_VER=8.18.2
           curl -fsSL "https://ftp.sendmail.org/pub/sendmail/sendmail.${SENDMAIL_VER}.tar.gz" | tar xz -C /tmp
           cd /tmp/sendmail-${SENDMAIL_VER}/libmilter
+          ls /tmp/sendmail-${SENDMAIL_VER}/  # debug: confirm extraction layout
           ./Build
+          find . -name "libmilter.a"  # debug: show actual output path
           OBJDIR=$(echo obj.*)
           sudo mkdir -p /usr/local/include/libmilter /usr/local/lib
           sudo cp ../include/sendmail.h /usr/local/include/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,14 +83,10 @@ jobs:
           SENDMAIL_VER=8.18.2
           curl -fsSL "ftp://ftp.sendmail.org/pub/sendmail/sendmail.${SENDMAIL_VER}.tar.gz" | tar xz -C /tmp
           cd /tmp/sendmail-${SENDMAIL_VER}/libmilter
-          ls /tmp/sendmail-${SENDMAIL_VER}/  # debug: confirm extraction layout
           ./Build
-          find . -name "libmilter.a"  # debug: show actual output path
-          OBJDIR=$(echo obj.*)
           sudo mkdir -p /usr/local/include/libmilter /usr/local/lib
-          sudo cp ../include/sendmail.h /usr/local/include/
           sudo cp mfapi.h mfdef.h /usr/local/include/libmilter/
-          sudo cp ${OBJDIR}/libmilter.a /usr/local/lib/
+          sudo cp libmilter.a /usr/local/lib/
 
       - name: Build miltertest
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
           ./Build
           sudo mkdir -p /usr/local/include/libmilter /usr/local/lib
           sudo cp ../include/libmilter/mfapi.h ../include/libmilter/mfdef.h /usr/local/include/libmilter/
-          sudo cp "$(find . -name 'libmilter.a' | head -1)" /usr/local/lib/
+          sudo cp "$(find .. -name 'libmilter.a' | head -1)" /usr/local/lib/
 
       - name: Build miltertest
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           cd /tmp/miltertest
           autoreconf -fvi
           ./configure \
-            CFLAGS='-g -O2 -Wno-pointer-sign' \
+            CFLAGS='-g -O2 -Wno-pointer-sign -std=gnu11' \
             CPPFLAGS="-I$(brew --prefix openssl)/include -I/usr/local/include" \
             LDFLAGS="-L$(brew --prefix openssl)/lib -L/usr/local/lib"
           make -j$(sysctl -n hw.logicalcpu)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           cd /tmp/sendmail-${SENDMAIL_VER}/libmilter
           ./Build
           sudo mkdir -p /usr/local/include/libmilter /usr/local/lib
-          sudo cp mfapi.h mfdef.h /usr/local/include/libmilter/
+          sudo cp ../include/libmilter/mfapi.h ../include/libmilter/mfdef.h /usr/local/include/libmilter/
           sudo cp libmilter.a /usr/local/lib/
 
       - name: Build miltertest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Build and install libmilter from source
         run: |
           SENDMAIL_VER=8.18.2
-          curl -fsSL "https://ftp.sendmail.org/pub/sendmail/sendmail.${SENDMAIL_VER}.tar.gz" | tar xz -C /tmp
+          curl -fsSL "ftp://ftp.sendmail.org/pub/sendmail/sendmail.${SENDMAIL_VER}.tar.gz" | tar xz -C /tmp
           cd /tmp/sendmail-${SENDMAIL_VER}/libmilter
           ls /tmp/sendmail-${SENDMAIL_VER}/  # debug: confirm extraction layout
           ./Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Configure
         run: |
           ./configure --enable-live-tests \
-            CFLAGS='-g -O2 -Wno-pointer-sign' \
+            CFLAGS='-g -O2 -Wno-pointer-sign -std=gnu11' \
             CPPFLAGS="-I$(brew --prefix openssl)/include -I/usr/local/include" \
             LDFLAGS="-L$(brew --prefix openssl)/lib -L/usr/local/lib"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
           ./Build
           sudo mkdir -p /usr/local/include/libmilter /usr/local/lib
           sudo cp ../include/libmilter/mfapi.h ../include/libmilter/mfdef.h /usr/local/include/libmilter/
-          sudo cp obj.*/libmilter/libmilter.a /usr/local/lib/
+          sudo cp "$(find . -name 'libmilter.a' | head -1)" /usr/local/lib/
 
       - name: Build miltertest
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,54 @@ jobs:
 
       - name: Test
         run: make check
+
+  build-test-macos:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          brew install \
+            autoconf automake libtool pkg-config \
+            openssl libmilter \
+            lua \
+            cpanminus
+          cpanm --notest DBI LWP IO::Compress JSON Net::DNS
+
+      - name: Build miltertest
+        run: |
+          git clone --depth=1 https://github.com/thegushi/miltertest.git /tmp/miltertest
+          cd /tmp/miltertest
+          autoreconf -fvi
+          ./configure \
+            CFLAGS='-g -O2 -Wno-pointer-sign' \
+            CPPFLAGS="-I$(brew --prefix openssl)/include -I$(brew --prefix libmilter)/include" \
+            LDFLAGS="-L$(brew --prefix openssl)/lib -L$(brew --prefix libmilter)/lib"
+          make -j$(sysctl -n hw.logicalcpu)
+          sudo make install
+
+      - name: Bootstrap build system
+        run: autoreconf -fvi
+
+      - name: Configure
+        run: |
+          ./configure --enable-live-tests \
+            CFLAGS='-g -O2 -Wno-pointer-sign' \
+            CPPFLAGS="-I$(brew --prefix openssl)/include -I$(brew --prefix libmilter)/include" \
+            LDFLAGS="-L$(brew --prefix openssl)/lib -L$(brew --prefix libmilter)/lib"
+
+      - name: Build
+        run: make -j$(sysctl -n hw.logicalcpu)
+
+      - name: Check Perl syntax
+        run: |
+          perl -c reports/opendmarc-expire
+          perl -c reports/opendmarc-import
+          perl -c reports/opendmarc-importstats
+          perl -c reports/opendmarc-params
+          perl -c reports/opendmarc-reports
+
+      - name: Test
+        run: make check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
           ./Build
           sudo mkdir -p /usr/local/include/libmilter /usr/local/lib
           sudo cp ../include/libmilter/mfapi.h ../include/libmilter/mfdef.h /usr/local/include/libmilter/
-          sudo cp libmilter.a /usr/local/lib/
+          sudo cp obj.*/libmilter/libmilter.a /usr/local/lib/
 
       - name: Build miltertest
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,22 @@ jobs:
         run: |
           brew install \
             autoconf automake libtool pkg-config \
-            openssl sendmail \
+            openssl \
             lua \
             cpanminus
           cpanm --notest DBI LWP IO::Compress JSON Net::DNS
+
+      - name: Build and install libmilter from source
+        run: |
+          SENDMAIL_VER=8.18.1
+          curl -fsSL "https://ftp.sendmail.org/pub/sendmail/sendmail.${SENDMAIL_VER}.tar.gz" | tar xz -C /tmp
+          cd /tmp/sendmail-${SENDMAIL_VER}/libmilter
+          ./Build
+          OBJDIR=$(echo obj.*)
+          sudo mkdir -p /usr/local/include/libmilter /usr/local/lib
+          sudo cp ../include/sendmail.h /usr/local/include/
+          sudo cp mfapi.h mfdef.h /usr/local/include/libmilter/
+          sudo cp ${OBJDIR}/libmilter.a /usr/local/lib/
 
       - name: Build miltertest
         run: |
@@ -85,8 +97,8 @@ jobs:
           autoreconf -fvi
           ./configure \
             CFLAGS='-g -O2 -Wno-pointer-sign' \
-            CPPFLAGS="-I$(brew --prefix openssl)/include -I$(brew --prefix sendmail)/include" \
-            LDFLAGS="-L$(brew --prefix openssl)/lib -L$(brew --prefix sendmail)/lib"
+            CPPFLAGS="-I$(brew --prefix openssl)/include -I/usr/local/include" \
+            LDFLAGS="-L$(brew --prefix openssl)/lib -L/usr/local/lib"
           make -j$(sysctl -n hw.logicalcpu)
           sudo make install
 
@@ -97,8 +109,8 @@ jobs:
         run: |
           ./configure --enable-live-tests \
             CFLAGS='-g -O2 -Wno-pointer-sign' \
-            CPPFLAGS="-I$(brew --prefix openssl)/include -I$(brew --prefix sendmail)/include" \
-            LDFLAGS="-L$(brew --prefix openssl)/lib -L$(brew --prefix sendmail)/lib"
+            CPPFLAGS="-I$(brew --prefix openssl)/include -I/usr/local/include" \
+            LDFLAGS="-L$(brew --prefix openssl)/lib -L/usr/local/lib"
 
       - name: Build
         run: make -j$(sysctl -n hw.logicalcpu)

--- a/CHANGES-202605.md
+++ b/CHANGES-202605.md
@@ -167,6 +167,9 @@ CREATE TABLE IF NOT EXISTS suppressions (
 
 ## Build system and portability
 
+- **`opendmarc_policy_fetch_fo()` missing from public header**: The function was implemented and documented but never declared in `dmarc.h.in`, causing a build failure on Clang 15+ (including Apple Clang 21 on macOS) where implicit function declarations are a hard error rather than a warning. (#408, issue #407)
+- **macOS CI job added**: GitHub Actions now builds and tests on `macos-latest` in addition to `ubuntu-latest`, catching Clang-strict build failures that go undetected on the Linux/GCC job. libmilter is built from the sendmail source tarball; `-std=gnu11` is required because sendmail's `mfapi.h` typedef's `bool`, which conflicts with C23 where `bool` is a keyword.
+
 - **`opendmarc-spf-parse.c` missing from `Makefile.am`**: The Received-SPF parser source file added in the crash fixes was not listed in `opendmarc_SOURCES`, causing a link failure on clean builds. (#335, issue #334)
 - **Perl path hardcoded in report scripts**: `#!/usr/bin/perl` was hardcoded in `opendmarc-reports`, `opendmarc-import`, and related scripts. The path is now detected by `configure` and substituted as `@PERL@`. (#318)
 - **`Switch` module dependency removed**: The report scripts used `Switch`, which was removed from core Perl in 5.36 and requires a separate CPAN install on modern systems. All `switch`/`case` blocks have been converted to `if`/`elsif`/`else`. (#336)

--- a/libopendmarc/dmarc.h.in
+++ b/libopendmarc/dmarc.h.in
@@ -142,6 +142,7 @@ OPENDMARC_STATUS_T opendmarc_policy_fetch_adkim(DMARC_POLICY_T *pctx, int *adkim
 OPENDMARC_STATUS_T opendmarc_policy_fetch_aspf(DMARC_POLICY_T *pctx, int *aspf);
 OPENDMARC_STATUS_T opendmarc_policy_fetch_p(DMARC_POLICY_T *pctx, int *p);
 OPENDMARC_STATUS_T opendmarc_policy_fetch_sp(DMARC_POLICY_T *pctx, int *sp);
+OPENDMARC_STATUS_T opendmarc_policy_fetch_fo(DMARC_POLICY_T *pctx, int *fo);
 u_char **	   opendmarc_policy_fetch_rua(DMARC_POLICY_T *pctx, u_char *list_buf, size_t size_of_buf, int constant);
 u_char **	   opendmarc_policy_fetch_ruf(DMARC_POLICY_T *pctx, u_char *list_buf, size_t size_of_buf, int constant);
 OPENDMARC_STATUS_T opendmarc_policy_fetch_utilized_domain(DMARC_POLICY_T *pctx, u_char *buf, size_t buflen);


### PR DESCRIPTION
## Summary

- Adds a `build-test-macos` job to CI running on `macos-latest`
- Builds libmilter from the sendmail 8.18.2 source tarball (no Homebrew formula exists)
- Builds miltertest with `-std=gnu11` to avoid a conflict with `mfapi.h`'s `typedef int bool` in C23
- All 10 unit tests pass locally on Apple Clang 21 / macOS 15

This catches Clang-strict build failures like the missing `opendmarc_policy_fetch_fo()` declaration fixed in #408 / issue #407, which went undetected on the Linux/GCC job.

## Test plan

- [ ] CI macOS job passes end-to-end
- [ ] Reporter on issue #407 confirms fix works on their machine