### PR TITLE
tests: gate t-verify-self-spf on TEST_SPF conditional (#411)

### DIFF
--- a/opendmarc/tests/Makefile.am
+++ b/opendmarc/tests/Makefile.am
@@ -6,7 +6,13 @@ if LIVE_TESTS
 check_SCRIPTS += t-verify-multi-from-reject t-verify-multi-from-malformed \
 	t-verify-nodata t-verify-nodata-reject \
 	t-verify-unspec t-verify-received-spf-good t-verify-received-spf-bad \
-	t-verify-self-spf t-verify-authservid-jobid
+	t-verify-authservid-jobid
+endif
+
+if TEST_SPF
+if LIVE_TESTS
+check_SCRIPTS += t-verify-self-spf
+endif
 endif
 
 TESTS = $(check_SCRIPTS)


### PR DESCRIPTION
## Summary

- Moves `t-verify-self-spf` out of the unconditional `LIVE_TESTS` block and into a `TEST_SPF` guard in `opendmarc/tests/Makefile.am`.

## Problem

`t-verify-self-spf` exercises `SPFSelfValidate Yes`, which is entirely behind `#if WITH_SPF` in `opendmarc.c`. Without `--with-spf` at configure time the config option is silently ignored and the test fails (rather than skips) because no `spf=fail` result appears in Authentication-Results. Both CI jobs configure without `--with-spf`, so this test blocks the macOS CI added in #409.

Note: `--with-spf` without libspf2 would use the internal `opendmarc_spf_test()` implementation, but that implementation is under active consideration for removal. Gating on `TEST_SPF` is the correct long-term approach regardless.

## Fix

```makefile
if TEST_SPF
if LIVE_TESTS
check_SCRIPTS += t-verify-self-spf
endif
endif
```

`TEST_SPF` is the existing autoconf conditional set by `--with-spf`, already used in `configure.ac`.

Closes #411.

🤖 Generated with [Claude Code](https://claude.com/claude-code)