### PR TITLE
warn when PublicSuffixList is more than 6 months old

### DIFF
--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -1667,6 +1667,22 @@ dmarcf_config_reload(void)
 				dmarcf_config_free(new);
 				err = TRUE;
 			}
+			else if (new->conf_dolog)
+			{
+				struct stat pslst;
+
+				if (stat(new->conf_pslist, &pslst) == 0)
+				{
+					time_t age = time(NULL) - pslst.st_mtime;
+					/* 180 days in seconds */
+					if (age > 180 * 24 * 60 * 60)
+					{
+						syslog(LOG_WARNING,
+						       "%s: public suffix list is more than 6 months old; consider getting a fresh copy from https://publicsuffix.org/list/public_suffix_list.dat",
+						       new->conf_pslist);
+					}
+				}
+			}
 		}
 
 		if (!err)


### PR DESCRIPTION
## Summary

- After a successful `opendmarc_tld_read_file()` call, `stat()` the configured `PublicSuffixList` file
- If the mtime is older than 180 days, emit a `LOG_WARNING` (guarded by `conf_dolog`) directing operators to fetch a fresh copy
- Warning includes the canonical download URL so operators know exactly where to go

## Test plan

- [ ] Configure a `PublicSuffixList` pointing to a file with an mtime > 6 months ago; confirm the warning appears in syslog on startup/reload
- [ ] Confirm no warning for a recently-touched file
- [ ] Confirm no warning (and no crash) when `PublicSuffixList` is not configured