### PR TITLE
contrib: survey script fixes and enhancements

### DIFF
--- a/contrib/dmarc-pct-survey.pl
+++ b/contrib/dmarc-pct-survey.pl
@@ -17,6 +17,12 @@ use IO::Uncompress::Unzip qw(unzip $UnzipError);
 #   pct_value: numeric value if present, "-" if absent
 #   psd_value: "y", "n", or "-" if absent
 #   t_value:   "y", "n", or "-" if absent
+#
+# Extra output (--extra-output or dated file): TSV of _dmarc records found at label
+#   levels above the queried domains that are NOT themselves in the top-1M input.
+#   Columns: run_date, domain, triggered_by, trigger_has_dmarc, pct, psd, t, record
+#   trigger_has_dmarc: 1 if the triggering domain itself had a v=DMARC1 record, 0 if not
+#   triggered_by: the top-1M domain whose label walk first enqueued this parent.
 # Progress/stats (STDERR): running count + final summary
 
 my $umbrella_url = 'https://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.zip';
@@ -27,17 +33,19 @@ my $infile       = 'top-1m.csv';
 my $max_domains  = 0;     # 0 = unlimited
 my $nameserver;           # undef = system default
 my $outfile;              # undef = use dated default
+my $extrafile;            # undef = use dated default
 my $summarylog   = 'dmarc-pct-survey-summary.tsv';
 
 GetOptions(
-    'concurrency=i' => \$concurrency,
-    'timeout=i'     => \$timeout,
-    'input=s'       => \$infile,
-    'output=s'      => \$outfile,
-    'max=i'         => \$max_domains,
-    'nameserver=s'  => \$nameserver,
-    'summary-log=s' => \$summarylog,
-) or die "Usage: $0 [--input FILE] [--output FILE] [--summary-log FILE] [--concurrency N] [--timeout N] [--max N] [--nameserver IP]\n";
+    'concurrency=i'  => \$concurrency,
+    'timeout=i'      => \$timeout,
+    'input=s'        => \$infile,
+    'output=s'       => \$outfile,
+    'extra-output=s' => \$extrafile,
+    'max=i'          => \$max_domains,
+    'nameserver=s'   => \$nameserver,
+    'summary-log=s'  => \$summarylog,
+) or die "Usage: $0 [--input FILE] [--output FILE] [--extra-output FILE] [--summary-log FILE] [--concurrency N] [--timeout N] [--max N] [--nameserver IP]\n";
 
 unless (-f $infile) {
     my $zipfile = $infile . '.zip';
@@ -54,6 +62,9 @@ my $run_date = strftime('%Y-%m-%d', localtime);
 
 if (!defined($outfile)) {
     $outfile = sprintf('dmarc-pct-survey-%s.tsv', $run_date);
+}
+if (!defined($extrafile)) {
+    $extrafile = sprintf('dmarc-pct-survey-%s-extra.tsv', $run_date);
 }
 
 my $resolver = Net::DNS::Resolver->new(
@@ -81,6 +92,12 @@ my $n_t_n      = 0;  # has t=n
 my $n_pct100_noop = 0;  # p=reject or p=quarantine with pct=100 (a no-op)
 my $n_none_pct    = 0;  # p=none with any pct= value (has no effect)
 my $n_errors   = 0;
+
+my %has_dmarc;  # domains that returned a v=DMARC1 record in the main phase
+
+# Parent-walk tracking: domains we directly queried, and unlisted parents to check.
+my %known_domains;
+my %extra_parents;  # parent_domain => first_triggering_child
 
 # In-flight: socket => [ domain, dispatch_time ]
 my %inflight;
@@ -115,6 +132,7 @@ sub harvest {
         my $pkt = eval { $resolver->bgread($sock) };
         unless ($pkt) {
             $n_errors++;
+            print $out "# error: $domain\n";
             next;
         }
 
@@ -122,6 +140,11 @@ sub harvest {
         # NXDOMAIN and NOERROR-with-no-answers are normal (domain has no record)
         next if $rcode eq 'NXDOMAIN';
         next if $rcode eq 'NOERROR' && !($pkt->answer);
+        if ($rcode ne 'NOERROR') {
+            $n_errors++;
+            print $out "# $rcode: $domain\n";
+            next;
+        }
 
         for my $rr ($pkt->answer) {
             next unless $rr->type eq 'TXT';
@@ -129,6 +152,7 @@ sub harvest {
             next unless $txt =~ /^v=DMARC1\b/i;
 
             $n_dmarc++;
+            $has_dmarc{$domain} = 1;
 
             my $pct = ($txt =~ /\bpct=(\d+)/i)  ? $1      : '-';
             my $psd = ($txt =~ /\bpsd=([yn])/i)  ? lc($1) : '-';
@@ -164,10 +188,76 @@ sub reap_stale {
     my $now = time();
     for my $sock (keys %inflight) {
         if ($now - $inflight{$sock}[1] > $timeout * 2) {
+            my ($domain) = @{$inflight{$sock}};
             delete $inflight{$sock};
             $sel->remove($sock);
             $n_errors++;
             $n_done++;
+            print $out "# timeout: $domain\n";
+        }
+    }
+}
+
+sub reap_stale_extra {
+    my ($fh) = @_;
+    my $now = time();
+    for my $sock (keys %inflight) {
+        if ($now - $inflight{$sock}[1] > $timeout * 2) {
+            my ($domain) = @{$inflight{$sock}};
+            delete $inflight{$sock};
+            $sel->remove($sock);
+            $n_errors++;
+            print $fh "# timeout: $domain\n";
+        }
+    }
+}
+
+sub parent_labels {
+    my ($domain) = @_;
+    my @labels = split(/\./, $domain);
+    my @parents;
+    shift @labels;
+    while (@labels) {
+        push @parents, join('.', @labels);
+        shift @labels;
+    }
+    return @parents;
+}
+
+sub harvest_extra {
+    my ($fh, $n_extra_dmarc_ref, $block) = @_;
+    my @ready = $block ? $sel->can_read($timeout) : $sel->can_read(0);
+    for my $sock (@ready) {
+        my $meta = delete $inflight{$sock};
+        $sel->remove($sock);
+        my ($domain, undef, $triggered_by) = @$meta;
+
+        my $pkt = eval { $resolver->bgread($sock) };
+        unless ($pkt) { $n_errors++; print $fh "# error: $domain\n"; next; }
+
+        my $rcode = $pkt->header->rcode;
+        next if $rcode eq 'NXDOMAIN';
+        next if $rcode eq 'NOERROR' && !($pkt->answer);
+        if ($rcode ne 'NOERROR') {
+            $n_errors++;
+            print $fh "# $rcode: $domain\n";
+            next;
+        }
+
+        for my $rr ($pkt->answer) {
+            next unless $rr->type eq 'TXT';
+            my $txt = join('', $rr->txtdata);
+            next unless $txt =~ /^v=DMARC1\b/i;
+
+            $$n_extra_dmarc_ref++;
+
+            my $pct = ($txt =~ /\bpct=(\d+)/i)  ? $1      : '-';
+            my $psd = ($txt =~ /\bpsd=([yn])/i)  ? lc($1) : '-';
+            my $t   = ($txt =~ /\bt=([yn])/i)    ? lc($1) : '-';
+
+            my $trigger_has_dmarc = $has_dmarc{$triggered_by} ? 1 : 0;
+            print $fh join("\t", $run_date, $domain, $triggered_by, $trigger_has_dmarc, $pct, $psd, $t, $txt), "\n";
+            last;
         }
     }
 }
@@ -184,6 +274,11 @@ while (my $line = <$fh>) {
     my $domain = ($line =~ /^\d+,(.+)$/) ? $1 : $line;
     $domain =~ s/^\s+|\s+$//g;
     next unless $domain =~ /\./;
+
+    $known_domains{$domain} = 1;
+    for my $parent (parent_labels($domain)) {
+        $extra_parents{$parent} //= $domain;
+    }
 
     dispatch($domain);
 
@@ -220,6 +315,39 @@ while (%inflight) {
 
 close($out);
 
+# --- Extra phase: walk parent labels not directly queried ---
+delete $extra_parents{$_} for keys %known_domains;
+
+open(my $extra, '>:encoding(UTF-8)', $extrafile) or die "Cannot open $extrafile: $!\n";
+print $extra join("\t", "run_date", "domain", "triggered_by", "trigger_has_dmarc", "pct", "psd", "t", "record"), "\n";
+
+my $n_extra_queued = 0;
+my $n_extra_dmarc  = 0;
+
+print STDERR "\nRunning parent-label walk, writing $extrafile ...\n";
+
+for my $parent (sort keys %extra_parents) {
+    my $triggered_by = $extra_parents{$parent};
+    my $socket = $resolver->bgsend("_dmarc.$parent", 'TXT');
+    unless ($socket) { $n_errors++; next; }
+    $inflight{$socket} = [ $parent, time(), $triggered_by ];
+    $sel->add($socket);
+    $n_extra_queued++;
+
+    while (scalar(keys %inflight) >= $concurrency) {
+        harvest_extra($extra, \$n_extra_dmarc, 1);
+        reap_stale_extra($extra);
+    }
+    harvest_extra($extra, \$n_extra_dmarc, 0);
+}
+
+while (%inflight) {
+    harvest_extra($extra, \$n_extra_dmarc, 1);
+    reap_stale_extra($extra);
+}
+
+close($extra);
+
 printf STDERR "\nDone. Output written to %s\n", $outfile;
 printf STDERR "  Domains queried : %d\n", $n_done;
 printf STDERR "  Errors          : %d\n", $n_errors;
@@ -233,6 +361,9 @@ printf STDERR "    t=y           : %d\n", $n_t_y;
 printf STDERR "    t=n           : %d\n", $n_t_n;
 printf STDERR "  p=reject/quarantine with pct=100 (no-op) : %d\n", $n_pct100_noop;
 printf STDERR "  p=none with pct= (no effect)             : %d\n", $n_none_pct;
+printf STDERR "Parent-label walk (%s):\n", $extrafile;
+printf STDERR "  Unlisted parents checked : %d\n", $n_extra_queued;
+printf STDERR "  Unlisted parents w/DMARC : %d\n", $n_extra_dmarc;
 
 my $is_new = !-f $summarylog;
 open(my $sum, '>>', $summarylog) or die "Cannot open $summarylog: $!\n";

--- a/contrib/dmarc-psd-survey.pl
+++ b/contrib/dmarc-psd-survey.pl
@@ -24,6 +24,12 @@ binmode(STDERR, ':encoding(UTF-8)');
 #   exception: 1 if the PSL entry was an exception (!foo.bar)
 #   psd:       "y", "n", or "-" if absent
 #   record:    full DMARC TXT record
+#
+# Extra output (--extra-output or dated file): TSV of _dmarc records found at label
+#   levels above PSL entries that are NOT themselves in the PSL.
+#   Columns: run_date, domain, triggered_by, trigger_has_dmarc, psd, record
+#   trigger_has_dmarc: 1 if the triggering PSL entry itself had a v=DMARC1 record, 0 if not
+#   triggered_by: the PSL entry whose label walk first enqueued this parent.
 # Progress/stats (STDERR): running count + final summary
 
 my $psl_url     = 'https://publicsuffix.org/list/public_suffix_list.dat';
@@ -35,6 +41,7 @@ my $max_entries  = 0;   # 0 = unlimited
 my $nameserver;         # undef = system default
 my $icann_only   = 0;   # if set, skip private domains section
 my $outfile;            # undef = use dated default
+my $extrafile;          # undef = use dated default
 my $summarylog   = 'dmarc-psd-survey-summary.tsv';
 
 GetOptions(
@@ -42,11 +49,12 @@ GetOptions(
     'timeout=i'      => \$timeout,
     'input=s'        => \$infile,
     'output=s'       => \$outfile,
+    'extra-output=s' => \$extrafile,
     'summary-log=s'  => \$summarylog,
     'max=i'         => \$max_entries,
     'nameserver=s'  => \$nameserver,
     'icann-only!'   => \$icann_only,
-) or die "Usage: $0 [--input FILE] [--output FILE] [--concurrency N] [--timeout N] [--max N] [--nameserver IP] [--icann-only]\n";
+) or die "Usage: $0 [--input FILE] [--output FILE] [--extra-output FILE] [--concurrency N] [--timeout N] [--max N] [--nameserver IP] [--icann-only]\n";
 
 my $run_date = strftime('%Y-%m-%d', localtime);
 
@@ -59,6 +67,9 @@ unless (-f $infile) {
 
 if (!defined($outfile)) {
     $outfile = sprintf('dmarc-psd-survey-%s.tsv', $run_date);
+}
+if (!defined($extrafile)) {
+    $extrafile = sprintf('dmarc-psd-survey-%s-extra.tsv', $run_date);
 }
 
 my $resolver = Net::DNS::Resolver->new(
@@ -80,6 +91,12 @@ my $n_psd       = 0;  # has psd= in record
 my $n_psd_y     = 0;  # has psd=y
 my $n_psd_n     = 0;  # has psd=n
 my $n_errors    = 0;
+
+my %has_dmarc;  # PSL entries that returned a v=DMARC1 record in the main phase
+
+# Parent-walk tracking: entries we directly queried, and unlisted parents to check.
+my %known_entries;
+my %extra_parents;  # parent_domain => first_triggering_entry
 
 # In-flight: socket => [ suffix, section, wildcard, exception, dispatch_time ]
 my %inflight;
@@ -106,10 +123,12 @@ sub reap_stale {
     my $now = time();
     for my $sock (keys %inflight) {
         if ($now - $inflight{$sock}[4] > $timeout * 2) {
+            my ($suffix) = @{$inflight{$sock}};
             delete $inflight{$sock};
             $sel->remove($sock);
             $n_errors++;
             $n_done++;
+            print $out "# timeout: $suffix\n";
         }
     }
 }
@@ -127,12 +146,18 @@ sub harvest {
         my $pkt = eval { $resolver->bgread($sock) };
         unless ($pkt) {
             $n_errors++;
+            print $out "# error: $suffix\n";
             next;
         }
 
         my $rcode = $pkt->header->rcode;
         next if $rcode eq 'NXDOMAIN';
         next if $rcode eq 'NOERROR' && !($pkt->answer);
+        if ($rcode ne 'NOERROR') {
+            $n_errors++;
+            print $out "# $rcode: $suffix\n";
+            next;
+        }
 
         for my $rr ($pkt->answer) {
             next unless $rr->type eq 'TXT';
@@ -140,6 +165,7 @@ sub harvest {
             next unless $txt =~ /^v=DMARC1\b/i;
 
             $n_dmarc++;
+            $has_dmarc{$suffix} = 1;
 
             my $psd = ($txt =~ /\bpsd=([yn])/i) ? lc($1) : '-';
 
@@ -151,6 +177,69 @@ sub harvest {
 
             print $out join("\t", $run_date, $suffix, $section, $wildcard, $exception, $psd, $txt), "\n";
             last;  # only evaluate first v=DMARC1 record
+        }
+    }
+}
+
+sub parent_labels {
+    my ($domain) = @_;
+    my @labels = split(/\./, $domain);
+    my @parents;
+    shift @labels;
+    while (@labels) {
+        push @parents, join('.', @labels);
+        shift @labels;
+    }
+    return @parents;
+}
+
+# Extra-phase reap: inflight metadata is [ domain, dispatch_time, triggered_by ]
+sub reap_stale_extra {
+    my ($fh) = @_;
+    my $now = time();
+    for my $sock (keys %inflight) {
+        if ($now - $inflight{$sock}[1] > $timeout * 2) {
+            my ($domain) = @{$inflight{$sock}};
+            delete $inflight{$sock};
+            $sel->remove($sock);
+            $n_errors++;
+            print $fh "# timeout: $domain\n";
+        }
+    }
+}
+
+sub harvest_extra {
+    my ($fh, $n_extra_dmarc_ref, $block) = @_;
+    my @ready = $block ? $sel->can_read($timeout) : $sel->can_read(0);
+    for my $sock (@ready) {
+        my $meta = delete $inflight{$sock};
+        $sel->remove($sock);
+        my ($domain, undef, $triggered_by) = @$meta;
+
+        my $pkt = eval { $resolver->bgread($sock) };
+        unless ($pkt) { $n_errors++; print $fh "# error: $domain\n"; next; }
+
+        my $rcode = $pkt->header->rcode;
+        next if $rcode eq 'NXDOMAIN';
+        next if $rcode eq 'NOERROR' && !($pkt->answer);
+        if ($rcode ne 'NOERROR') {
+            $n_errors++;
+            print $fh "# $rcode: $domain\n";
+            next;
+        }
+
+        for my $rr ($pkt->answer) {
+            next unless $rr->type eq 'TXT';
+            my $txt = join('', $rr->txtdata);
+            next unless $txt =~ /^v=DMARC1\b/i;
+
+            $$n_extra_dmarc_ref++;
+
+            my $psd = ($txt =~ /\bpsd=([yn])/i) ? lc($1) : '-';
+
+            my $trigger_has_dmarc = $has_dmarc{$triggered_by} ? 1 : 0;
+            print $fh join("\t", $run_date, $domain, $triggered_by, $trigger_has_dmarc, $psd, $txt), "\n";
+            last;
         }
     }
 }
@@ -206,6 +295,11 @@ while (my $line = <$fh>) {
         $entry = $ace;
     }
 
+    $known_entries{$entry} = 1;
+    for my $parent (parent_labels($entry)) {
+        $extra_parents{$parent} //= $entry;
+    }
+
     dispatch($entry, $section, $wildcard, $exception);
 
     while (scalar(keys %inflight) >= $concurrency) {
@@ -237,6 +331,39 @@ while (%inflight) {
 
 close($out);
 
+# --- Extra phase: walk parent labels not directly queried ---
+delete $extra_parents{$_} for keys %known_entries;
+
+open(my $extra, '>:encoding(UTF-8)', $extrafile) or die "Cannot open $extrafile: $!\n";
+print $extra join("\t", "run_date", "domain", "triggered_by", "trigger_has_dmarc", "psd", "record"), "\n";
+
+my $n_extra_queued = 0;
+my $n_extra_dmarc  = 0;
+
+print STDERR "\nRunning parent-label walk, writing $extrafile ...\n";
+
+for my $parent (sort keys %extra_parents) {
+    my $triggered_by = $extra_parents{$parent};
+    my $socket = $resolver->bgsend("_dmarc.$parent", 'TXT');
+    unless ($socket) { $n_errors++; next; }
+    $inflight{$socket} = [ $parent, time(), $triggered_by ];
+    $sel->add($socket);
+    $n_extra_queued++;
+
+    while (scalar(keys %inflight) >= $concurrency) {
+        harvest_extra($extra, \$n_extra_dmarc, 1);
+        reap_stale_extra($extra);
+    }
+    harvest_extra($extra, \$n_extra_dmarc, 0);
+}
+
+while (%inflight) {
+    harvest_extra($extra, \$n_extra_dmarc, 1);
+    reap_stale_extra($extra);
+}
+
+close($extra);
+
 printf STDERR "\nDone. Output written to %s\n", $outfile;
 printf STDERR "  Suffixes queried : %d\n",                                                $n_done;
 printf STDERR "  Errors           : %d\n",                                                $n_errors;
@@ -244,6 +371,9 @@ printf STDERR "  Have DMARC       : %d (%.1f%%)\n",          $n_dmarc, $n_done  
 printf STDERR "  Have psd=        : %d (%.1f%% of DMARC)\n", $n_psd,   $n_dmarc  ? 100*$n_psd/$n_dmarc    : 0;
 printf STDERR "    psd=y          : %d\n",                                                $n_psd_y;
 printf STDERR "    psd=n          : %d\n",                                                $n_psd_n;
+printf STDERR "Parent-label walk (%s):\n", $extrafile;
+printf STDERR "  Unlisted parents checked : %d\n", $n_extra_queued;
+printf STDERR "  Unlisted parents w/DMARC : %d\n", $n_extra_dmarc;
 
 my $is_new = !-f $summarylog;
 open(my $sum, '>>', $summarylog) or die "Cannot open $summarylog: $!\n";

--- a/contrib/dmarc-root-survey.pl
+++ b/contrib/dmarc-root-survey.pl
@@ -1,0 +1,197 @@
+#!/usr/local/bin/perl
+use strict;
+use warnings;
+use Net::DNS;
+use IO::Select;
+use Getopt::Long;
+use POSIX qw(strftime);
+
+# Query every delegated TLD in the DNS root zone for DMARC records.
+# Obtains the TLD list via AXFR from a root zone transfer server rather
+# than a static file, so it always reflects current delegations.
+#
+# Default transfer server: xfr.lax.dns.icann.org (IANA's public xfr service).
+# F-root (f.root-servers.net / 192.5.5.241) also works.
+#
+# Output (--output or dated file): TSV - run_date, tld, psd, record
+#   run_date: ISO 8601 date of this run (YYYY-MM-DD)
+#   tld:      bare TLD label (e.g. "com", "co.uk" is not here -- only root delegations)
+#   psd:      "y", "n", or "-" if absent
+#   record:   full DMARC TXT record
+# Progress/stats (STDERR): running count + final summary
+
+my $xfr_server   = 'xfr.lax.dns.icann.org';
+my $concurrency  = 100;
+my $timeout      = 5;
+my $nameserver;           # undef = system default for _dmarc queries
+my $outfile;              # undef = use dated default
+my $summarylog   = 'dmarc-root-survey-summary.tsv';
+
+GetOptions(
+    'xfr-server=s'  => \$xfr_server,
+    'concurrency=i' => \$concurrency,
+    'timeout=i'     => \$timeout,
+    'output=s'      => \$outfile,
+    'nameserver=s'  => \$nameserver,
+    'summary-log=s' => \$summarylog,
+) or die "Usage: $0 [--xfr-server HOST] [--output FILE] [--summary-log FILE] [--concurrency N] [--timeout N] [--nameserver IP]\n";
+
+my $run_date = strftime('%Y-%m-%d', localtime);
+
+if (!defined($outfile)) {
+    $outfile = sprintf('dmarc-root-survey-%s.tsv', $run_date);
+}
+
+# AXFR the root zone to get delegated TLDs.
+print STDERR "Fetching root zone via AXFR from $xfr_server ...\n";
+
+my $xfr_resolver = Net::DNS::Resolver->new(
+    nameservers => [$xfr_server],
+    usevc       => 1,
+    tcp_timeout => 60,
+);
+
+my %tlds;
+my @xfr = $xfr_resolver->axfr('.');
+die "AXFR failed: " . $xfr_resolver->errorstring . "\n" unless @xfr;
+
+for my $rr (@xfr) {
+    next unless $rr->type eq 'NS';
+    my $owner = lc($rr->owner);
+    $owner =~ s/\.$//;       # strip trailing dot
+    next unless length($owner);   # skip root '.' itself
+    next if $owner =~ /\./;       # skip anything below TLD level
+    $tlds{$owner} = 1;
+}
+
+my @tlds = sort keys %tlds;
+printf STDERR "  %d delegated TLDs found\n", scalar @tlds;
+
+# Now query _dmarc for each TLD.
+my $resolver = Net::DNS::Resolver->new(
+    udp_timeout => $timeout,
+    tcp_timeout => $timeout,
+    retrans     => 1,
+    retry       => 1,
+    ($nameserver ? (nameservers => [$nameserver]) : ()),
+);
+
+open(my $out, '>:encoding(UTF-8)', $outfile) or die "Cannot open $outfile: $!\n";
+
+# Stats
+my $n_done   = 0;
+my $n_dmarc  = 0;
+my $n_psd    = 0;
+my $n_psd_y  = 0;
+my $n_psd_n  = 0;
+my $n_errors = 0;
+
+# In-flight: socket => [ tld, dispatch_time ]
+my %inflight;
+my $sel = IO::Select->new;
+
+my $progress_interval = 100;
+my $next_progress     = $progress_interval;
+
+sub reap_stale {
+    my $now = time();
+    for my $sock (keys %inflight) {
+        if ($now - $inflight{$sock}[1] > $timeout * 2) {
+            my ($tld) = @{$inflight{$sock}};
+            delete $inflight{$sock};
+            $sel->remove($sock);
+            $n_errors++;
+            $n_done++;
+            print $out "# timeout: $tld\n";
+        }
+    }
+}
+
+sub harvest {
+    my ($block) = @_;
+    my @ready = $block ? $sel->can_read($timeout) : $sel->can_read(0);
+    for my $sock (@ready) {
+        my $meta = delete $inflight{$sock};
+        $sel->remove($sock);
+        $n_done++;
+        my ($tld) = @$meta;
+
+        my $pkt = eval { $resolver->bgread($sock) };
+        unless ($pkt) { $n_errors++; print $out "# error: $tld\n"; next; }
+
+        my $rcode = $pkt->header->rcode;
+        next if $rcode eq 'NXDOMAIN';
+        next if $rcode eq 'NOERROR' && !($pkt->answer);
+        if ($rcode ne 'NOERROR') {
+            $n_errors++;
+            print $out "# $rcode: $tld\n";
+            next;
+        }
+
+        for my $rr ($pkt->answer) {
+            next unless $rr->type eq 'TXT';
+            my $txt = join('', $rr->txtdata);
+            next unless $txt =~ /^v=DMARC1\b/i;
+
+            $n_dmarc++;
+
+            my $psd = ($txt =~ /\bpsd=([yn])/i) ? lc($1) : '-';
+            if ($psd ne '-') {
+                $n_psd++;
+                $n_psd_y++ if $psd eq 'y';
+                $n_psd_n++ if $psd eq 'n';
+            }
+
+            print $out join("\t", $run_date, $tld, $psd, $txt), "\n";
+            last;
+        }
+    }
+}
+
+print $out join("\t", "run_date", "tld", "psd", "record"), "\n";
+print STDERR "Querying _dmarc for ${\scalar @tlds} TLDs, writing $outfile, concurrency=$concurrency, timeout=${timeout}s\n";
+
+for my $tld (@tlds) {
+    my $socket = $resolver->bgsend("_dmarc.$tld", 'TXT');
+    unless ($socket) { $n_errors++; next; }
+    $inflight{$socket} = [ $tld, time() ];
+    $sel->add($socket);
+
+    while (scalar(keys %inflight) >= $concurrency) {
+        harvest(1);
+        reap_stale();
+    }
+    harvest(0);
+
+    if ($n_done >= $next_progress) {
+        printf STDERR "  %d done, %d in-flight, %d dmarc\n",
+            $n_done, scalar(keys %inflight), $n_dmarc;
+        $next_progress += $progress_interval;
+    }
+}
+
+while (%inflight) {
+    harvest(1);
+    reap_stale();
+    if ($n_done >= $next_progress) {
+        printf STDERR "  %d done, %d in-flight, %d dmarc\n",
+            $n_done, scalar(keys %inflight), $n_dmarc;
+        $next_progress += $progress_interval;
+    }
+}
+
+close($out);
+
+printf STDERR "\nDone. Output written to %s\n", $outfile;
+printf STDERR "  TLDs queried  : %d\n", $n_done;
+printf STDERR "  Errors        : %d\n", $n_errors;
+printf STDERR "  Have DMARC    : %d (%.1f%%)\n", $n_dmarc, $n_done ? 100*$n_dmarc/$n_done : 0;
+printf STDERR "  Have psd=     : %d (%.1f%% of DMARC)\n", $n_psd, $n_dmarc ? 100*$n_psd/$n_dmarc : 0;
+printf STDERR "    psd=y       : %d\n", $n_psd_y;
+printf STDERR "    psd=n       : %d\n", $n_psd_n;
+
+my $is_new = !-f $summarylog;
+open(my $sum, '>>', $summarylog) or die "Cannot open $summarylog: $!\n";
+print $sum join("\t", qw(run_date queried errors have_dmarc psd_total psd_y psd_n)), "\n" if $is_new;
+print $sum join("\t", $run_date, $n_done, $n_errors, $n_dmarc, $n_psd, $n_psd_y, $n_psd_n), "\n";
+close($sum);


### PR DESCRIPTION
## Summary

- fix: reap stale DNS sockets in throttle loop in dmarc-pct-survey.pl and dmarc-psd-survey.pl
- fix: open output TSV with UTF-8 encoding in dmarc-pct-survey.pl and dmarc-psd-survey.pl
- feat: track DMARCbis t= (testing) tag in dmarc-pct-survey.pl
- feat: count no-op pct= usage (pct=100 or absent) in dmarc-pct-survey.pl
- feat: walk parent labels and report unlisted _dmarc records in dmarc-psd-survey.pl
- feat: add trigger_has_dmarc field to extra output in survey scripts
- fix: log error domains as comments in pct- and psd-survey output files
- fix: print errored TLDs as comments in dmarc-root-survey.pl output
- fix: axfr() returns a list, not an array ref
- fix: use reap_stale_extra in extra phase to avoid writing to closed output handle
- feat: add dmarc-root-survey.pl to check _dmarc at every root zone TLD via AXFR

## Test plan

- [x] Run dmarc-root-survey.pl and confirm TSV output and summary log are written
- [x] Run dmarc-psd-survey.pl with --extra-output and confirm trigger_has_dmarc column is present
- [x] Run dmarc-pct-survey.pl and confirm t= and no-op pct= columns appear in output
- [x] Confirm output files open cleanly in tools that expect UTF-8