### PR TITLE
fix: resolve char/u_char pointer-sign compiler warnings

### DIFF
--- a/libopendmarc/opendmarc_policy.c
+++ b/libopendmarc/opendmarc_policy.c
@@ -84,7 +84,7 @@ opendmarc_policy_library_init(OPENDMARC_LIB_T *lib_init)
 		switch (Opendmarc_Libp->tld_type)
 		{
 			case OPENDMARC_TLD_TYPE_MOZILLA:
-				ret = opendmarc_tld_read_file(Opendmarc_Libp->tld_source_file,
+				ret = opendmarc_tld_read_file((char *)Opendmarc_Libp->tld_source_file,
 						"//", "*.", "!");
 				if (ret != 0)
 					ret = errno;
@@ -287,24 +287,24 @@ opendmarc_policy_check_alignment(u_char *subdomain, u_char *tld, int mode)
 		mode= DMARC_RECORD_A_RELAXED;
 
 	(void) memset(tld_buf, '\0', sizeof tld_buf);
-	(void) strlcpy(tld_buf, tld, sizeof tld_buf);
+	(void) strlcpy((char *)tld_buf, (char *)tld, sizeof tld_buf);
 
 	(void) memset(rev_sub, '\0', sizeof rev_sub);
 	(void) opendmarc_reverse_domain(subdomain, rev_sub, sizeof rev_sub);
-	ep = rev_sub + strlen(rev_sub) -1;
+	ep = rev_sub + strlen((char *)rev_sub) -1;
 	if (*ep != '.')
 		(void) strlcat((char *)rev_sub, ".", sizeof rev_sub);
 
 	(void) memset(rev_tld, '\0', sizeof rev_tld);
 	(void) opendmarc_reverse_domain(tld_buf,   rev_tld, sizeof rev_tld);
-	ep = rev_tld + strlen(rev_tld) -1;
+	ep = rev_tld + strlen((char *)rev_tld) -1;
 	if (*ep != '.')
 		(void) strlcat((char *)rev_tld, ".", sizeof rev_tld);
 
 	/*
 	 * Perfect match is aligned irrespective of relaxed or strict.
 	 */
-	if (strcasecmp(rev_tld, rev_sub) == 0)
+	if (strcasecmp((char *)rev_tld, (char *)rev_sub) == 0)
 		return 0;
 
 	/*
@@ -314,11 +314,11 @@ opendmarc_policy_check_alignment(u_char *subdomain, u_char *tld, int mode)
 	if (mode == DMARC_RECORD_A_STRICT)
 		return -1;
 
-	ret = strncasecmp(rev_tld, rev_sub, strlen(rev_tld));
+	ret = strncasecmp((char *)rev_tld, (char *)rev_sub, strlen((char *)rev_tld));
 	if (ret == 0 && mode == DMARC_RECORD_A_RELAXED)
 			return 0;
 
-        ret = strncasecmp(rev_sub, rev_tld, strlen(rev_sub));
+        ret = strncasecmp((char *)rev_sub, (char *)rev_tld, strlen((char *)rev_sub));
         if (ret == 0 && mode == DMARC_RECORD_A_RELAXED)
                         return 0;
 
@@ -327,21 +327,21 @@ opendmarc_policy_check_alignment(u_char *subdomain, u_char *tld, int mode)
 		return -1;
 	(void) memset(rev_tld, '\0', sizeof rev_tld);
 	(void) opendmarc_reverse_domain(tld_buf,   rev_tld, sizeof rev_tld);
-	ep = rev_tld + strlen(rev_tld) -1;
+	ep = rev_tld + strlen((char *)rev_tld) -1;
 	if (*ep != '.')
 		(void) strlcat((char *)rev_tld, ".", sizeof rev_tld);
 
 	/*
 	 * Perfect match is aligned irrespective of relaxed or strict.
 	 */
-	if (strcasecmp(rev_tld, rev_sub) == 0)
+	if (strcasecmp((char *)rev_tld, (char *)rev_sub) == 0)
 		return 0;
 
-	ret = strncasecmp(rev_tld, rev_sub, strlen(rev_tld));
+	ret = strncasecmp((char *)rev_tld, (char *)rev_sub, strlen((char *)rev_tld));
 	if (ret == 0 && mode == DMARC_RECORD_A_RELAXED)
 			return 0;
 
-        ret = strncasecmp(rev_sub, rev_tld, strlen(rev_sub));
+        ret = strncasecmp((char *)rev_sub, (char *)rev_tld, strlen((char *)rev_sub));
         if (ret == 0 && mode == DMARC_RECORD_A_RELAXED)
                         return 0;
 	return -1;
@@ -377,10 +377,10 @@ opendmarc_policy_store_from_domain(DMARC_POLICY_T *pctx, u_char *from_domain)
 		return DMARC_PARSE_ERROR_NULL_CTX;
 	if (from_domain == NULL || strlen((char *)from_domain) == 0)
 		return DMARC_PARSE_ERROR_EMPTY;
-	dp = opendmarc_util_finddomain(from_domain, domain_buf, sizeof domain_buf);
+	dp = (char *)opendmarc_util_finddomain(from_domain, (u_char *)domain_buf, sizeof domain_buf);
 	if (dp == NULL)
 		return DMARC_PARSE_ERROR_NO_DOMAIN;
-	pctx->from_domain = strdup((char *)dp);
+	pctx->from_domain = (u_char *)strdup((char *)dp);
 	if (pctx->from_domain == NULL)
 		return DMARC_PARSE_ERROR_NO_ALLOC;
 	return DMARC_PARSE_OKAY;
@@ -422,14 +422,14 @@ opendmarc_policy_store_spf(DMARC_POLICY_T *pctx, u_char *domain, int result, int
 		return DMARC_PARSE_ERROR_NULL_CTX;
 	if (domain == NULL || strlen((char *)domain) == 0)
 		return DMARC_PARSE_ERROR_EMPTY;
-	dp = opendmarc_util_finddomain(domain, domain_buf, sizeof domain_buf);
+	dp = (char *)opendmarc_util_finddomain(domain, (u_char *)domain_buf, sizeof domain_buf);
 	if (dp == NULL)
 		return DMARC_PARSE_ERROR_NO_DOMAIN;
-	if (!check_domain(dp))
+	if (!check_domain((u_char *)dp))
 		return DMARC_PARSE_ERROR_BAD_VALUE;
 	if (human_readable != NULL)
-		pctx->spf_human_outcome = strdup((char *)human_readable);
-	pctx->spf_domain = strdup((char *)dp);
+		pctx->spf_human_outcome = (u_char *)strdup((char *)human_readable);
+	pctx->spf_domain = (u_char *)strdup((char *)dp);
 	if (pctx->spf_domain == NULL)
 		return DMARC_PARSE_ERROR_NO_ALLOC;
 	switch (result)
@@ -513,8 +513,8 @@ opendmarc_policy_store_dkim(DMARC_POLICY_T *pctx, u_char *d_equal_domain,
 	if (pctx->dkim_final == TRUE)
 		return DMARC_PARSE_OKAY;
 
-	dp = opendmarc_util_finddomain(d_equal_domain, domain_buf, sizeof domain_buf);
-	if (dp == NULL || strlen(dp) == 0)
+	dp = opendmarc_util_finddomain(d_equal_domain, (u_char *)domain_buf, sizeof domain_buf);
+	if (dp == NULL || strlen((char *)dp) == 0)
 		return DMARC_PARSE_ERROR_NO_DOMAIN;
 
 	/*
@@ -522,7 +522,7 @@ opendmarc_policy_store_dkim(DMARC_POLICY_T *pctx, u_char *d_equal_domain,
 	 * select this one as the domain of choice.
 	 * If the outcome is pass, make this the final choice.
 	 */
-	if (strcasecmp((char *)dp, pctx->from_domain) == 0)
+	if (strcasecmp((char *)dp, (char *)pctx->from_domain) == 0)
 	{
 		if (pctx->dkim_domain != NULL)
 		{
@@ -579,16 +579,16 @@ opendmarc_policy_store_dkim(DMARC_POLICY_T *pctx, u_char *d_equal_domain,
 
 set_final:
 	if (pctx->dkim_domain == NULL)
-		pctx->dkim_domain = strdup((char *)dp);
+		pctx->dkim_domain = (u_char *)strdup((char *)dp);
 	if (pctx->dkim_domain == NULL)
 		return DMARC_PARSE_ERROR_NO_ALLOC;
 	if (pctx->dkim_selector == NULL && s_equal_selector != NULL)
-		pctx->dkim_selector = strdup((char *)s_equal_selector);
+		pctx->dkim_selector = (u_char *)strdup((char *)s_equal_selector);
 	if (human_result != NULL)
 	{
 		if (pctx->dkim_human_outcome != NULL)
 			(void) free(pctx->dkim_human_outcome);
-		pctx->dkim_human_outcome = strdup((char *)human_result);
+		pctx->dkim_human_outcome = (u_char *)strdup((char *)human_result);
 	}
 	pctx->dkim_outcome = result;
 	return DMARC_PARSE_OKAY;
@@ -637,7 +637,7 @@ opendmarc_policy_query_dmarc_xdomain(DMARC_POLICY_T *pctx, u_char *uri)
 	memset(uri_tld, '\0', sizeof uri_tld);
 
 	/* Get out domain from our URI */
-	if (strncasecmp(uri, "mailto:", 7) == 0)
+	if (strncasecmp((char *)uri, "mailto:", 7) == 0)
 		uri += 7;
 
 	if (opendmarc_util_finddomain(uri, domain, sizeof domain) == NULL)
@@ -673,7 +673,7 @@ opendmarc_policy_query_dmarc_xdomain(DMARC_POLICY_T *pctx, u_char *uri)
 			continue;
 		}
 	}
-	if (dns_reply == NETDB_SUCCESS && strcmp( buf, "&" ) != 0)
+	if (dns_reply == NETDB_SUCCESS && strcmp( (char *)buf, "&" ) != 0)
 	{
 		/* Must include DMARC version */
 		if (strncasecmp((char *)buf, "v=DMARC1", sizeof buf) == 0)
@@ -702,7 +702,7 @@ opendmarc_policy_query_dmarc_xdomain(DMARC_POLICY_T *pctx, u_char *uri)
 			continue;
 		}
 	}
-	if (dns_reply == NETDB_SUCCESS && strcmp( buf, "&" ) != 0)
+	if (dns_reply == NETDB_SUCCESS && strcmp( (char *)buf, "&" ) != 0)
 	{
 		/* Must include DMARC version */
 		if (strncasecmp((char *)buf, "v=DMARC1", sizeof buf) == 0)
@@ -771,7 +771,7 @@ opendmarc_policy_query_dmarc(DMARC_POLICY_T *pctx, u_char *domain)
 
 	if (pctx == NULL)
 		return DMARC_PARSE_ERROR_NULL_CTX;
-	if (domain == NULL || strlen(domain) == 0)
+	if (domain == NULL || strlen((char *)domain) == 0)
 	{
 		if (pctx->from_domain != NULL)
 			domain = pctx->from_domain;
@@ -779,12 +779,12 @@ opendmarc_policy_query_dmarc(DMARC_POLICY_T *pctx, u_char *domain)
 			return DMARC_PARSE_ERROR_EMPTY;
 	}
 
-	(void) strlcpy(copy, "_dmarc.", sizeof copy);
-	(void) strlcat(copy, domain, sizeof copy);
+	(void) strlcpy((char *)copy, "_dmarc.", sizeof copy);
+	(void) strlcat((char *)copy, (char *)domain, sizeof copy);
 
 query_again:
 	(void) memset(buf, '\0', sizeof buf);
-	bp = dmarc_dns_get_record(copy, &dns_reply, buf, sizeof buf);
+	bp = (u_char *)dmarc_dns_get_record((char *)copy, &dns_reply, (char *)buf, sizeof buf);
 	if (bp != NULL)
 	{
 		if (dns_reply != HOST_NOT_FOUND)
@@ -796,7 +796,7 @@ query_again:
 	 */
 	if (bp == NULL && *buf != '\0')
 	{
-		(void) strlcpy(copy, buf, sizeof copy);
+		(void) strlcpy((char *)copy, (char *)buf, sizeof copy);
 		if (--loop_count != 0)
 			goto query_again;
 	}
@@ -811,16 +811,16 @@ query_again:
 	 * queried domain, try exactly that domain and stop.  Per RFC 7489
 	 * §6.6.3 we look at one domain: the organizational domain.
 	 */
-	if (strlen(tld) > 0 && strcasecmp((char *)tld, (char *)domain) != 0)
+	if (strlen((char *)tld) > 0 && strcasecmp((char *)tld, (char *)domain) != 0)
 	{
-		pctx->organizational_domain = strdup(tld);
+		pctx->organizational_domain = (u_char *)strdup((char *)tld);
 
 		loop_count = DNS_MAX_RETRIES;
-		(void) strlcpy(copy, "_dmarc.", sizeof copy);
-		(void) strlcat(copy, tld, sizeof copy);
+		(void) strlcpy((char *)copy, "_dmarc.", sizeof copy);
+		(void) strlcat((char *)copy, (char *)tld, sizeof copy);
 query_again2:
 		(void) memset(buf, '\0', sizeof buf);
-		bp = dmarc_dns_get_record(copy, &dns_reply, buf, sizeof buf);
+		bp = (u_char *)dmarc_dns_get_record((char *)copy, &dns_reply, (char *)buf, sizeof buf);
 		if (bp != NULL)
 			goto got_record;
 		/*
@@ -828,7 +828,7 @@ query_again2:
 		 */
 		if (bp == NULL && *buf != '\0')
 		{
-			(void) strlcpy(copy, buf, sizeof copy);
+			(void) strlcpy((char *)copy, (char *)buf, sizeof copy);
 			if (--loop_count != 0)
 				goto query_again2;
 		}
@@ -858,14 +858,14 @@ query_again2:
 				break;
 
 			loop_count = DNS_MAX_RETRIES;
-			(void) strlcpy(copy, "_dmarc.", sizeof copy);
-			(void) strlcat(copy, cur, sizeof copy);
+			(void) strlcpy((char *)copy, "_dmarc.", sizeof copy);
+			(void) strlcat((char *)copy, (char *)cur, sizeof copy);
 query_again3:
 			(void) memset(buf, '\0', sizeof buf);
-			bp = dmarc_dns_get_record(copy, &dns_reply, buf, sizeof buf);
+			bp = (u_char *)dmarc_dns_get_record((char *)copy, &dns_reply, (char *)buf, sizeof buf);
 			if (bp != NULL)
 			{
-				pctx->organizational_domain = strdup(cur);
+				pctx->organizational_domain = (u_char *)strdup((char *)cur);
 				pctx->org_domain_from_fallback = 1;
 				goto got_record;
 			}
@@ -874,7 +874,7 @@ query_again3:
 			 */
 			if (bp == NULL && *buf != '\0')
 			{
-				(void) strlcpy(copy, buf, sizeof copy);
+				(void) strlcpy((char *)copy, (char *)buf, sizeof copy);
 				if (--loop_count != 0)
 					goto query_again3;
 			}
@@ -1022,7 +1022,7 @@ opendmarc_policy_parse_dmarc(DMARC_POLICY_T *pctx, u_char *domain, u_char *recor
 
 	for (cp = copy; cp != NULL && cp <= ep; )
 	{
-		sp = (u_char *)strchr(cp, ';');
+		sp = (u_char *)strchr((char *)cp, ';');
 		if (sp != NULL)
 			*sp++ = '\0';
 		eqp = (u_char *)strchr((char *)cp, '=');
@@ -1133,7 +1133,7 @@ opendmarc_policy_parse_dmarc(DMARC_POLICY_T *pctx, u_char *domain, u_char *recor
 		else if (strcasecmp((char *)cp, "pct") == 0)
 		{
 			errno = 0;
-			pctx->pct = strtoul(vp, NULL, 10);
+			pctx->pct = strtoul((char *)vp, NULL, 10);
 			if (pctx->pct < 0 || pctx->pct > 100)
 			{
 				return DMARC_PARSE_ERROR_BAD_VALUE;
@@ -1147,13 +1147,13 @@ opendmarc_policy_parse_dmarc(DMARC_POLICY_T *pctx, u_char *domain, u_char *recor
 		{
 			char *xp;
 
-			for (xp = vp; *xp != '\0'; ++xp)
+			for (xp = (char *)vp; *xp != '\0'; ++xp)
 			{
 				if (! isdigit((int)*xp))
 					return DMARC_PARSE_ERROR_BAD_VALUE;
 			}
 			errno = 0;
-			pctx->ri = strtoul(vp, NULL, 10);
+			pctx->ri = strtoul((char *)vp, NULL, 10);
 			if (errno == EINVAL || errno == ERANGE)
 			{
 				return DMARC_PARSE_ERROR_BAD_VALUE;
@@ -1166,7 +1166,7 @@ opendmarc_policy_parse_dmarc(DMARC_POLICY_T *pctx, u_char *domain, u_char *recor
 			/*
 			 * The list may be a comma delimilted list of choices.
 			 */
-			for (xp = vp; *xp != '\0'; )
+			for (xp = (char *)vp; *xp != '\0'; )
 			{
 				u_char xbuf[32];
 
@@ -1174,7 +1174,7 @@ opendmarc_policy_parse_dmarc(DMARC_POLICY_T *pctx, u_char *domain, u_char *recor
 				if (yp != NULL)
 					*yp = '\0';
 
-				xp = opendmarc_util_cleanup(xp, xbuf, sizeof xbuf);
+				xp = (char *)opendmarc_util_cleanup((u_char *)xp, xbuf, sizeof xbuf);
 				if (xp != NULL && strlen((char *)xp) > 0)
 				{
 					/*
@@ -1213,7 +1213,7 @@ opendmarc_policy_parse_dmarc(DMARC_POLICY_T *pctx, u_char *domain, u_char *recor
 			if (pctx->rua_list != NULL)
 				return DMARC_PARSE_ERROR_BAD_VALUE;
 
-			for (xp = vp; *xp != '\0'; )
+			for (xp = (char *)vp; *xp != '\0'; )
 			{
 				u_char	xbuf[256];
 
@@ -1221,10 +1221,10 @@ opendmarc_policy_parse_dmarc(DMARC_POLICY_T *pctx, u_char *domain, u_char *recor
 				if (yp != NULL)
 					*yp = '\0';
 
-				xp = opendmarc_util_cleanup(xp, xbuf, sizeof xbuf);
+				xp = (char *)opendmarc_util_cleanup((u_char *)xp, xbuf, sizeof xbuf);
 				if (xp != NULL && strlen((char *)xp) > 0)
 				{
-					pctx->rua_list = opendmarc_util_pushargv(xp, pctx->rua_list,
+					pctx->rua_list = opendmarc_util_pushargv((u_char *)xp, pctx->rua_list,
 										&(pctx->rua_cnt));
 				}
 				else
@@ -1250,7 +1250,7 @@ opendmarc_policy_parse_dmarc(DMARC_POLICY_T *pctx, u_char *domain, u_char *recor
 			if (pctx->ruf_list != NULL)
 				return DMARC_PARSE_ERROR_BAD_VALUE;
 
-			for (xp = vp; *xp != '\0'; )
+			for (xp = (char *)vp; *xp != '\0'; )
 			{
 				u_char	xbuf[256];
 
@@ -1258,10 +1258,10 @@ opendmarc_policy_parse_dmarc(DMARC_POLICY_T *pctx, u_char *domain, u_char *recor
 				if (yp != NULL)
 					*yp = '\0';
 
-				xp = opendmarc_util_cleanup(xp, xbuf, sizeof xbuf);
+				xp = (char *)opendmarc_util_cleanup((u_char *)xp, xbuf, sizeof xbuf);
 				if (xp != NULL && strlen((char *)xp) > 0)
 				{
-					pctx->ruf_list = opendmarc_util_pushargv(xp, pctx->ruf_list,
+					pctx->ruf_list = opendmarc_util_pushargv((u_char *)xp, pctx->ruf_list,
 										&(pctx->ruf_cnt));
 				}
 				else
@@ -1282,7 +1282,7 @@ opendmarc_policy_parse_dmarc(DMARC_POLICY_T *pctx, u_char *domain, u_char *recor
 			/*
 			 * A possibly colon delimited list of on character settings.
 			 */
-			for (xp = vp; *xp != '\0'; )
+			for (xp = (char *)vp; *xp != '\0'; )
 			{
 				u_char xbuf[256];
 
@@ -1290,7 +1290,7 @@ opendmarc_policy_parse_dmarc(DMARC_POLICY_T *pctx, u_char *domain, u_char *recor
 				if (yp != NULL)
 					*yp = '\0';
 
-				xp = opendmarc_util_cleanup(xp, xbuf, sizeof xbuf);
+				xp = (char *)opendmarc_util_cleanup((u_char *)xp, xbuf, sizeof xbuf);
 				if (xp != NULL && strlen((char *)xp) > 0)
 				{
 					switch ((int)*xp)
@@ -1349,7 +1349,7 @@ opendmarc_policy_parse_dmarc(DMARC_POLICY_T *pctx, u_char *domain, u_char *recor
 		pctx->fo = DMARC_RECORD_FO_0;
 
 	if (pctx->from_domain == NULL)
-		pctx->from_domain = strdup(domain);
+		pctx->from_domain = (u_char *)strdup((char *)domain);
 	return DMARC_PARSE_OKAY;
 }
 
@@ -1375,12 +1375,12 @@ opendmarc_policy_store_dmarc(DMARC_POLICY_T *pctx, u_char *dmarc_record, u_char 
 
 	if (pctx->from_domain != NULL)
 		(void) free(pctx->from_domain);
-	pctx->from_domain = strdup(domain);
+	pctx->from_domain = (u_char *)strdup((char *)domain);
 	if (organizationaldomain != NULL)
 	{
 		if (pctx->organizational_domain != NULL)
 			(void) free(pctx->organizational_domain);
-		pctx->organizational_domain = (u_char *)strdup(organizationaldomain);
+		pctx->organizational_domain = (u_char *)strdup((char *)organizationaldomain);
 	}
 	return DMARC_PARSE_OKAY;
 }
@@ -1822,7 +1822,7 @@ opendmarc_policy_to_buf(DMARC_POLICY_T *pctx, char *buf, size_t buflen)
 
 	if (strlcat(buf, "IP_ADDR=", buflen) >= buflen) return E2BIG;
 	if (pctx->ip_addr != NULL)
-		if (strlcat(buf, pctx->ip_addr, buflen) >= buflen) return E2BIG;
+		if (strlcat(buf, (char *)pctx->ip_addr, buflen) >= buflen) return E2BIG;
 	if (strlcat(buf, "\n", buflen) >= buflen) return E2BIG;
 
 	if (strlcat(buf, "IP_TYPE=", buflen) >= buflen) return E2BIG;
@@ -1841,7 +1841,7 @@ opendmarc_policy_to_buf(DMARC_POLICY_T *pctx, char *buf, size_t buflen)
 
 	if (strlcat(buf, "SPF_DOMAIN=", buflen) >= buflen) return E2BIG;
 	if (pctx->spf_domain != NULL)
-		if (strlcat(buf, pctx->spf_domain, buflen) >= buflen) return E2BIG;
+		if (strlcat(buf, (char *)pctx->spf_domain, buflen) >= buflen) return E2BIG;
 	if (strlcat(buf, "\n", buflen) >= buflen) return E2BIG;
 
 	if (strlcat(buf, "SPF_ORIGIN=", buflen) >= buflen) return E2BIG;
@@ -1879,7 +1879,7 @@ opendmarc_policy_to_buf(DMARC_POLICY_T *pctx, char *buf, size_t buflen)
 
 	if (strlcat(buf, "SPF_HUMAN_OUTCOME=", buflen) >= buflen) return E2BIG;
 	if (pctx->spf_human_outcome != NULL)
-		if (strlcat(buf, pctx->spf_human_outcome, buflen) >= buflen) return E2BIG;
+		if (strlcat(buf, (char *)pctx->spf_human_outcome, buflen) >= buflen) return E2BIG;
 	if (strlcat(buf, "\n", buflen) >= buflen) return E2BIG;
 
 	if (strlcat(buf, "DKIM_FINAL=", buflen) >= buflen) return E2BIG;
@@ -1897,12 +1897,12 @@ opendmarc_policy_to_buf(DMARC_POLICY_T *pctx, char *buf, size_t buflen)
 
 	if (strlcat(buf, "DKIM_DOMAIN=", buflen) >= buflen) return E2BIG;
 	if (pctx->dkim_domain != NULL)
-		if (strlcat(buf, pctx->dkim_domain, buflen) >= buflen) return E2BIG;
+		if (strlcat(buf, (char *)pctx->dkim_domain, buflen) >= buflen) return E2BIG;
 	if (strlcat(buf, "\n", buflen) >= buflen) return E2BIG;
 
 	if (strlcat(buf, "DKIM_SELECTOR=", buflen) >= buflen) return E2BIG;
 	if (pctx->dkim_selector != NULL)
-		if (strlcat(buf, pctx->dkim_selector, buflen) >= buflen) return E2BIG;
+		if (strlcat(buf, (char *)pctx->dkim_selector, buflen) >= buflen) return E2BIG;
 	if (strlcat(buf, "\n", buflen) >= buflen) return E2BIG;
 
 	if (strlcat(buf, "DKIM_OUTOME=", buflen) >= buflen) return E2BIG;
@@ -1926,7 +1926,7 @@ opendmarc_policy_to_buf(DMARC_POLICY_T *pctx, char *buf, size_t buflen)
 
 	if (strlcat(buf, "DKIM_HUMAN_OUTCOME=", buflen) >= buflen) return E2BIG;
 	if (pctx->dkim_human_outcome != NULL)
-		if (strlcat(buf, pctx->dkim_human_outcome, buflen) >= buflen) return E2BIG;
+		if (strlcat(buf, (char *)pctx->dkim_human_outcome, buflen) >= buflen) return E2BIG;
 	if (strlcat(buf, "\n", buflen) >= buflen) return E2BIG;
 
 	if (strlcat(buf, "DKIM_ALIGNMENT=", buflen) >= buflen) return E2BIG;
@@ -2079,7 +2079,7 @@ opendmarc_policy_to_buf(DMARC_POLICY_T *pctx, char *buf, size_t buflen)
 		{
 			if (strlcat(buf, ",", buflen) >= buflen) return E2BIG;
 		}
-		if (strlcat(buf, (pctx->rua_list)[i], buflen) >= buflen) return E2BIG;
+		if (strlcat(buf, (char *)(pctx->rua_list)[i], buflen) >= buflen) return E2BIG;
 	}
 	if (strlcat(buf, "\n", buflen) >= buflen) return E2BIG;
 
@@ -2090,7 +2090,7 @@ opendmarc_policy_to_buf(DMARC_POLICY_T *pctx, char *buf, size_t buflen)
 		{
 			if (strlcat(buf, ",", buflen) >= buflen) return E2BIG;
 		}
-		if (strlcat(buf, (pctx->ruf_list)[i], buflen) >= buflen) return E2BIG;
+		if (strlcat(buf, (char *)(pctx->ruf_list)[i], buflen) >= buflen) return E2BIG;
 	}
 	if (strlcat(buf, "\n", buflen) >= buflen) return E2BIG;
 

--- a/libopendmarc/opendmarc_tld.c
+++ b/libopendmarc/opendmarc_tld.c
@@ -47,14 +47,14 @@ opendmarc_reverse_domain(u_char *domain, u_char *buf, size_t buflen)
 		if (*cp !=  '.')
 			break;
 	}
-	if (strlen(cp) == 0)
+	if (strlen((char *)cp) == 0)
 	{
 		return EINVAL;
 	}
 	if (cp > domain)
 		--cp;
 	(void) memset((char *)copy, '\0', sizeof copy);
-	(void) strlcpy((char *)copy, cp, sizeof copy);
+	(void) strlcpy((char *)copy, (char *)cp, sizeof copy);
 	ep = copy + strlen((char *)copy);
 
 	/*
@@ -188,7 +188,7 @@ got_xn:
 		if (adddot == TRUE)
 			(void) strlcat((char *)revbuf, ".", sizeof revbuf);
 
-		if (opendmarc_hash_lookup(hashp, revbuf, (void *)revbuf, strlen(revbuf)) == NULL)
+		if (opendmarc_hash_lookup(hashp, (char *)revbuf, (void *)revbuf, strlen((char *)revbuf)) == NULL)
 			return 1;
 		nlines++;
 	}
@@ -261,16 +261,16 @@ opendmarc_get_tld(u_char *domain, u_char *tld, size_t tld_len)
 		/*
 		** No tld list was supplied so copy the domain and return.
 		*/
-		(void) strlcpy(tld, domain, tld_len);
+		(void) strlcpy((char *)tld, (char *)domain, tld_len);
 		return 0;
 	}
 
-	for (rp = revbuf + strlen(revbuf) -1; rp > revbuf; --rp)
+	for (rp = revbuf + strlen((char *)revbuf) -1; rp > revbuf; --rp)
 	{
 		if (rp == revbuf)
 		{
 			/* no match found in the hash table. */
-			(void) strlcpy(tld, domain, tld_len);
+			(void) strlcpy((char *)tld, (char *)domain, tld_len);
 			break;
 		}
 		if (*rp == '.')
@@ -280,7 +280,7 @@ opendmarc_get_tld(u_char *domain, u_char *tld, size_t tld_len)
 # if HAVE_PTHREAD_H || HAVE_PTHREAD
 			(void) pthread_mutex_lock(&TLD_hctx_mutex);
 # endif
-			vp = opendmarc_hash_lookup(TLD_hctx, revbuf, NULL, 0);
+			vp = opendmarc_hash_lookup(TLD_hctx, (char *)revbuf, NULL, 0);
 # if HAVE_PTHREAD_H || HAVE_PTHREAD
 			(void) pthread_mutex_unlock(&TLD_hctx_mutex);
 # endif
@@ -295,13 +295,13 @@ opendmarc_get_tld(u_char *domain, u_char *tld, size_t tld_len)
 # if HAVE_PTHREAD_H || HAVE_PTHREAD
 			(void) pthread_mutex_lock(&TLD_hctx_mutex);
 # endif
-			vp = opendmarc_hash_lookup(TLD_hctx, revbuf, NULL, 0);
+			vp = opendmarc_hash_lookup(TLD_hctx, (char *)revbuf, NULL, 0);
 # if HAVE_PTHREAD_H || HAVE_PTHREAD
 			(void) pthread_mutex_unlock(&TLD_hctx_mutex);
 # endif
 			if (vp != NULL)
 			{
-				char * cp = strchr(revbuf, '.');
+				char * cp = strchr((char *)revbuf, '.');
 
 				if (cp == NULL)
 					*rp = '.';

--- a/libopendmarc/opendmarc_util.c
+++ b/libopendmarc/opendmarc_util.c
@@ -76,7 +76,7 @@ opendmarc_util_pushargv(u_char *str, u_char **ary, int *cnt)
 		{
 			return NULL;
 		}
-		ary[0] = strdup(str);
+		ary[0] = (u_char *)strdup((char *)str);
 		ary[1] = NULL;
 		if (ary[0] == NULL)
 		{
@@ -104,7 +104,7 @@ opendmarc_util_pushargv(u_char *str, u_char **ary, int *cnt)
 		return NULL;
 	}
 	ary = tmp;
-	ary[i] = strdup(str);
+	ary[i] = (u_char *)strdup((char *)str);
 	if (ary[i] == NULL)
 	{
 		ary = opendmarc_util_clearargv(ary);
@@ -168,7 +168,7 @@ opendmarc_util_cleanup(u_char *str, u_char *buf, size_t buflen)
 
 	(void) memset(buf, '\0', buflen);
 
-	for (sp = str, ep = buf; *sp != '\0'; sp++)
+	for (sp = (char *)str, ep = (char *)buf; *sp != '\0'; sp++)
 	{
 		if (!isascii(*sp) || !isspace(*sp))
 			*ep++ = *sp;
@@ -214,7 +214,7 @@ opendmarc_util_finddomain(u_char *raw, u_char *buf, size_t buflen)
 	len = strlen((char *)raw);
 	if (len > BUFSIZ)
 		len = BUFSIZ - 1;
-	(void) strncpy(copy, raw, len);
+	(void) strncpy((char *)copy, (char *)raw, len);
 
 	/*
 	 * Quoted commas do not delimit addresses.
@@ -354,7 +354,7 @@ opendmarc_util_finddomain(u_char *raw, u_char *buf, size_t buflen)
 strip_local_part:
 	if (cp == NULL)
 		cp = copy;
-	ep = strchr(cp, '@');
+	ep = (u_char *)strchr((char *)cp, '@');
 	if (ep != NULL)
 		cp = ep + 1;
 	len = strlen((char *)cp);
@@ -370,7 +370,7 @@ strip_local_part:
 		if (*ep == '.')
 			*ep = '\0';
 	}
-	(void) strlcpy(buf, cp, buflen);
+	(void) strlcpy((char *)buf, (char *)cp, buflen);
 	return buf;
 }
 

--- a/opendmarc/opendmarc-arcares.c
+++ b/opendmarc/opendmarc-arcares.c
@@ -120,7 +120,7 @@ opendmarc_arcares_strip_whitespace(u_char *string)
 	/* set remaining chars to null */
 	memset(&string[a], '\0', b - a);
 
-	return string;
+	return (char *)string;
 }
 
 /*
@@ -196,7 +196,7 @@ opendmarc_arcares_arc_parse (struct arcares *aar,
 					if (p_found++)
 						return -1;
 
-					strlcpy(arc->smtpclientip,
+					strlcpy((char *)arc->smtpclientip,
 					        (char *) arc->arcresult.result_value[cp],
 					        sizeof arc->smtpclientip);
 				}

--- a/opendmarc/opendmarc-arcseal.c
+++ b/opendmarc/opendmarc-arcseal.c
@@ -113,7 +113,7 @@ opendmarc_arcseal_strip_whitespace(u_char *string)
 	/* set remaining chars to null */
 	memset(&string[a], '\0', b - a);
 
-	return string;
+	return (char *)string;
 }
 
 /*
@@ -145,9 +145,9 @@ opendmarc_arcseal_parse(u_char *hdr, struct arcseal *as)
 	memset(tmp, '\0', sizeof tmp);
 
 	// guarantee a null-terminated string
-	memcpy(tmp, hdr, MIN(strlen(hdr), sizeof tmp - 1));
+	memcpy(tmp, hdr, MIN(strlen((char *)hdr), sizeof tmp - 1));
 
-	while ((token = strsep((char **)&tmp_ptr, ";")) != NULL)
+	while ((token = (u_char *)strsep((char **)&tmp_ptr, ";")) != NULL)
 	{
 		size_t leading_space_len;
 		as_tag_t tag_code;
@@ -155,24 +155,24 @@ opendmarc_arcseal_parse(u_char *hdr, struct arcseal *as)
 		char *tag_label;
 		char *tag_value;
 
-		leading_space_len = strspn(token, " \r\n\t");
-		token_ptr = token + leading_space_len;
+		leading_space_len = strspn((char *)token, " \r\n\t");
+		token_ptr = (char *)token + leading_space_len;
 		if (*token_ptr == '\0')
 			return 0;
 		tag_label = strsep(&token_ptr, "=");
 		if (token_ptr == NULL)
 			return -1;
-		tag_value = opendmarc_arcseal_strip_whitespace(token_ptr);
+		tag_value = opendmarc_arcseal_strip_whitespace((u_char *)token_ptr);
 		tag_code = opendmarc_arcseal_convert(as_tags, tag_label);
 
 		switch (tag_code)
 		{
 		  case AS_TAG_ALGORITHM:
-			strlcpy(as->algorithm, tag_value, sizeof as->algorithm);
+			strlcpy((char *)as->algorithm, tag_value, sizeof as->algorithm);
 				break;
 
 		  case AS_TAG_CHAIN_VALIDATION:
-			strlcpy(as->chain_validation, tag_value, sizeof as->chain_validation);
+			strlcpy((char *)as->chain_validation, tag_value, sizeof as->chain_validation);
 			break;
 
 		  case AS_TAG_INSTANCE:
@@ -180,19 +180,19 @@ opendmarc_arcseal_parse(u_char *hdr, struct arcseal *as)
 			break;
 
 		  case AS_TAG_SIGNATURE_DOMAIN:
-			strlcpy(as->signature_domain, tag_value, sizeof as->signature_domain);
+			strlcpy((char *)as->signature_domain, tag_value, sizeof as->signature_domain);
 			break;
 
 		  case AS_TAG_SIGNATURE_SELECTOR:
-			strlcpy(as->signature_selector, tag_value, sizeof as->signature_selector);
+			strlcpy((char *)as->signature_selector, tag_value, sizeof as->signature_selector);
 			break;
 
 		  case AS_TAG_SIGNATURE_TIME:
-			strlcpy(as->signature_time, tag_value, sizeof as->signature_time);
+			strlcpy((char *)as->signature_time, tag_value, sizeof as->signature_time);
 			break;
 
 		  case AS_TAG_SIGNATURE_VALUE:
-			strlcpy(as->signature_value, tag_value, sizeof as->signature_value);
+			strlcpy((char *)as->signature_value, tag_value, sizeof as->signature_value);
 			break;
 
 		  default:

--- a/opendmarc/opendmarc-check.c
+++ b/opendmarc/opendmarc-check.c
@@ -92,7 +92,7 @@ main(int argc, char **argv)
 		return EX_SOFTWARE;
 	}
 
-	dmarc = opendmarc_policy_connect_init(LOCALHOST, FALSE);
+	dmarc = opendmarc_policy_connect_init((u_char *)LOCALHOST, FALSE);
 	if (dmarc == NULL)
 	{
 		fprintf(stderr, "%s: opendmarc_policy_connect_init() failed\n",
@@ -105,7 +105,7 @@ main(int argc, char **argv)
 	{
 		(void) opendmarc_policy_connect_rset(dmarc);
 
-		status = opendmarc_policy_store_from_domain(dmarc, argv[c]);
+		status = opendmarc_policy_store_from_domain(dmarc, (u_char *)argv[c]);
 		if (status != DMARC_PARSE_OKAY)
 		{
 			fprintf(stderr,

--- a/opendmarc/opendmarc.c
+++ b/opendmarc/opendmarc.c
@@ -1477,10 +1477,10 @@ dmarcf_config_load(struct config *data, struct dmarcf_config *conf,
 		ENTRY entry;
 		ENTRY *eptr;
 
-		domain = cur->list_str;
+		domain = (u_char *)cur->list_str;
 		dmarcf_lowercase(domain);
 
-		entry.key = domain;
+		entry.key = (char *)domain;
 		entry.data = (void *)domain;
 
 		/* keep track of the number of entries */
@@ -1983,7 +1983,7 @@ mlfi_connect(SMFICTX *ctx, char *host, _SOCK_ADDR *ip)
 		memcpy(&cc->cctx_ip, &sa, sizeof sa);
 		(void) inet_ntop(AF_INET, &sa.sin_addr, cc->cctx_ipstr,
 		                 sizeof cc->cctx_ipstr);
-		cc->cctx_dmarc = opendmarc_policy_connect_init(cc->cctx_ipstr,
+		cc->cctx_dmarc = opendmarc_policy_connect_init((u_char *)cc->cctx_ipstr,
 		                                               FALSE);
 	}
 	else if (ip->sa_family == AF_INET)
@@ -1993,7 +1993,7 @@ mlfi_connect(SMFICTX *ctx, char *host, _SOCK_ADDR *ip)
 		memcpy(&sa, ip, sizeof(struct sockaddr_in));
 		(void) inet_ntop(AF_INET, &sa.sin_addr, cc->cctx_ipstr,
 		                 sizeof cc->cctx_ipstr);
-		cc->cctx_dmarc = opendmarc_policy_connect_init(cc->cctx_ipstr,
+		cc->cctx_dmarc = opendmarc_policy_connect_init((u_char *)cc->cctx_ipstr,
 		                                               FALSE);
 
 		memcpy(&cc->cctx_ip, ip, sizeof(struct sockaddr_in));
@@ -2006,7 +2006,7 @@ mlfi_connect(SMFICTX *ctx, char *host, _SOCK_ADDR *ip)
 		memcpy(&sa, ip, sizeof(struct sockaddr_in6));
 		(void) inet_ntop(AF_INET6, &sa.sin6_addr, cc->cctx_ipstr,
 		                 sizeof cc->cctx_ipstr);
-		cc->cctx_dmarc = opendmarc_policy_connect_init(cc->cctx_ipstr,
+		cc->cctx_dmarc = opendmarc_policy_connect_init((u_char *)cc->cctx_ipstr,
 		                                               TRUE);
 
 		memcpy(&cc->cctx_ip, ip, sizeof(struct sockaddr_in6));
@@ -2141,10 +2141,10 @@ mlfi_envfrom(SMFICTX *ctx, char **envfrom)
 		strncpy(cc->cctx_rawmfrom, envfrom[0],
 			sizeof cc->cctx_rawmfrom - 1);
 #endif
-		strncpy(dfc->mctx_envfrom, envfrom[0],
+		strncpy((char *)dfc->mctx_envfrom, envfrom[0],
 		        sizeof dfc->mctx_envfrom - 1);
 
-		len = strlen(dfc->mctx_envfrom);
+		len = strlen((char *)dfc->mctx_envfrom);
 		p = dfc->mctx_envfrom;
 		q = dfc->mctx_envfrom + len - 1;
 
@@ -2161,9 +2161,9 @@ mlfi_envfrom(SMFICTX *ctx, char **envfrom)
 			memmove(dfc->mctx_envfrom, p, len + 1);
 		}
 
-		p = strchr(dfc->mctx_envfrom, '@');
+		p = (unsigned char *)strchr((char *)dfc->mctx_envfrom, '@');
 		if (p != NULL)
-			strlcpy(dfc->mctx_envdomain, p + 1, sizeof dfc->mctx_envdomain);
+			strlcpy((char *)dfc->mctx_envdomain, (char *)(p + 1), sizeof dfc->mctx_envdomain);
 	}
 
 	return SMFIS_CONTINUE;
@@ -2333,7 +2333,7 @@ mlfi_eom(SMFICTX *ctx)
 
 	if (strcmp((char *) dfc->mctx_jobid, JOBIDUNKNOWN) == 0)
 	{
-		dfc->mctx_jobid = (u_char *) dmarcf_getsymval(ctx, "i");
+		dfc->mctx_jobid = dmarcf_getsymval(ctx, "i");
 		if (dfc->mctx_jobid == NULL)
 		{
 			if (no_i_whine && conf->conf_dolog)
@@ -2342,7 +2342,7 @@ mlfi_eom(SMFICTX *ctx)
 				       "WARNING: symbol 'i' not available");
 				no_i_whine = FALSE;
 			}
-			dfc->mctx_jobid = (u_char *) JOBIDUNKNOWN;
+			dfc->mctx_jobid = JOBIDUNKNOWN;
 		}
 	}
 
@@ -2370,10 +2370,10 @@ mlfi_eom(SMFICTX *ctx)
 	 * value when a job ID is appended.
 	 */
 	if (conf->conf_authservidwithjobid && dfc->mctx_jobid[0] != '\0')
-		snprintf(authservid_hdr, sizeof authservid_hdr,
+		snprintf((char *)authservid_hdr, sizeof authservid_hdr,
 		         "\"%s/%s\"", authservid, dfc->mctx_jobid);
 	else
-		snprintf(authservid_hdr, sizeof authservid_hdr,
+		snprintf((char *)authservid_hdr, sizeof authservid_hdr,
 		         "%s", authservid);
 
 	/* ensure there was a From field */
@@ -2381,38 +2381,38 @@ mlfi_eom(SMFICTX *ctx)
 
 	/* verify RFC5322-required headers (RFC5322 3.6) */
 	if (from == NULL)
-		reqhdrs_error = "missing From field";
+		reqhdrs_error = (u_char *)"missing From field";
 	else if (dmarcf_findheader(dfc, "From", 1) != NULL)
-		reqhdrs_error = "multiple From fields";
+		reqhdrs_error = (u_char *)"multiple From fields";
 
 	if (dmarcf_findheader(dfc, "Date", 0) == NULL)
-		reqhdrs_error = "missing Date field";
+		reqhdrs_error = (u_char *)"missing Date field";
 	else if (dmarcf_findheader(dfc, "Date", 1) != NULL)
-		reqhdrs_error = "multiple Date fields";
+		reqhdrs_error = (u_char *)"multiple Date fields";
 
 	if (dmarcf_findheader(dfc, "Reply-To", 1) != NULL)
-		reqhdrs_error = "multiple Reply-To fields";
+		reqhdrs_error = (u_char *)"multiple Reply-To fields";
 
 	if (dmarcf_findheader(dfc, "To", 1) != NULL)
-		reqhdrs_error = "multiple To fields";
+		reqhdrs_error = (u_char *)"multiple To fields";
 
 	if (dmarcf_findheader(dfc, "Cc", 1) != NULL)
-		reqhdrs_error = "multiple Cc fields";
+		reqhdrs_error = (u_char *)"multiple Cc fields";
 
 	if (dmarcf_findheader(dfc, "Bcc", 1) != NULL)
-		reqhdrs_error = "multiple Bcc fields";
+		reqhdrs_error = (u_char *)"multiple Bcc fields";
 
 	if (dmarcf_findheader(dfc, "Message-Id", 1) != NULL)
-		reqhdrs_error = "multiple Message-Id fields";
+		reqhdrs_error = (u_char *)"multiple Message-Id fields";
 
 	if (dmarcf_findheader(dfc, "In-Reply-To", 1) != NULL)
-		reqhdrs_error = "multiple In-Reply-To fields";
+		reqhdrs_error = (u_char *)"multiple In-Reply-To fields";
 
 	if (dmarcf_findheader(dfc, "References", 1) != NULL)
-		reqhdrs_error = "multiple References fields";
+		reqhdrs_error = (u_char *)"multiple References fields";
 
 	if (dmarcf_findheader(dfc, "Subject", 1) != NULL)
-		reqhdrs_error = "multiple Subject fields";
+		reqhdrs_error = (u_char *)"multiple Subject fields";
 
 	if (conf->conf_reqhdrs && reqhdrs_error != NULL)
 	{
@@ -2424,7 +2424,7 @@ mlfi_eom(SMFICTX *ctx)
 		}
 
 		dmarcf_setreply(ctx, DMARC_REJECT_SMTP, DMARC_REJECT_ESC,
-		                reqhdrs_error);
+		                (char *)reqhdrs_error);
 		ret = SMFIS_REJECT;
 		goto done;
 	}
@@ -2454,8 +2454,8 @@ mlfi_eom(SMFICTX *ctx)
 
 	/* extract From: addresses */
 	memset(addrbuf, '\0', sizeof addrbuf);
-	strncpy(addrbuf, from->hdr_value, sizeof addrbuf - 1);
-	status = dmarcf_mail_parse_multi(addrbuf, &users, &domains, &froms);
+	strncpy((char *)addrbuf, from->hdr_value, sizeof addrbuf - 1);
+	status = dmarcf_mail_parse_multi((char *)addrbuf, &users, &domains, &froms);
 	if (status == 0 && domains[0] != NULL)
 	{
 		/*
@@ -2467,7 +2467,7 @@ mlfi_eom(SMFICTX *ctx)
 		for (c = 1; c < froms; c++)
 		{
 			if (domains[c] != NULL &&
-			    strcasecmp(domains[0], domains[c]) != 0)
+			    strcasecmp((char *)domains[0], (char *)domains[c]) != 0)
 			{
 				syslog(LOG_ERR,
 				       "%s: multi-valued From field detected",
@@ -2512,7 +2512,7 @@ mlfi_eom(SMFICTX *ctx)
 	}
 
 	if (conf->conf_ignoredomains != NULL &&
-	    dmarcf_match(domain, conf->conf_ignoredomains, TRUE))
+	    dmarcf_match((char *)domain, conf->conf_ignoredomains, TRUE))
 	{
 		if (conf->conf_dolog)
 		{
@@ -2524,7 +2524,7 @@ mlfi_eom(SMFICTX *ctx)
 		goto done;
 	}
 
-	strncpy(dfc->mctx_fromdomain, domain, sizeof dfc->mctx_fromdomain - 1);
+	strncpy((char *)dfc->mctx_fromdomain, (char *)domain, sizeof dfc->mctx_fromdomain - 1);
 
 	ostatus = opendmarc_policy_store_from_domain(cc->cctx_dmarc,
 	                                             dfc->mctx_fromdomain);
@@ -2578,7 +2578,7 @@ mlfi_eom(SMFICTX *ctx)
 		(void) memset(aar_hdr_new, '\0', sizeof(struct arcares_header));
 
 		/* parse it */
-		if (opendmarc_arcares_parse(hdr->hdr_value, &aar_hdr_new->arcares) != 0)
+		if (opendmarc_arcares_parse((u_char *)hdr->hdr_value, &aar_hdr_new->arcares) != 0)
 		{
 			syslog(LOG_WARNING,
 			       "%s: ignoring invalid %s header \"%s\"",
@@ -2627,7 +2627,7 @@ mlfi_eom(SMFICTX *ctx)
 		(void) memset(as_hdr_new, '\0', sizeof(struct arcseal_header));
 
 		/* parse it */
-		if (opendmarc_arcseal_parse(hdr->hdr_value, &as_hdr_new->arcseal) != 0)
+		if (opendmarc_arcseal_parse((u_char *)hdr->hdr_value, &as_hdr_new->arcseal) != 0)
 		{
 			syslog(LOG_WARNING,
 			       "%s: ignoring invalid %s header \"%s\"",
@@ -2663,13 +2663,13 @@ mlfi_eom(SMFICTX *ctx)
 
 		/* parse it */
 		memset(ar, '\0', sizeof *ar);
-		if (ares_parse(hdr->hdr_value, ar) != 0)
+		if (ares_parse((u_char *)hdr->hdr_value, ar) != 0)
 			continue;
 
 		/* skip it if it's not one of ours */
-		if (strcasecmp(ar->ares_host, authservid) != 0 &&
+		if (strcasecmp((char *)ar->ares_host, authservid) != 0 &&
 		    (conf->conf_trustedauthservids == NULL ||
-		     !dmarcf_match(ar->ares_host, conf->conf_trustedauthservids,
+		     !dmarcf_match((char *)ar->ares_host, conf->conf_trustedauthservids,
 		                   FALSE)))
 		{
 			unsigned char *slash;
@@ -2687,7 +2687,7 @@ mlfi_eom(SMFICTX *ctx)
 				continue;
 			}
 
-			slash = (unsigned char *) strchr(ar->ares_host, '/');
+			slash = (unsigned char *) strchr((char *)ar->ares_host, '/');
 			if (slash == NULL)
 			{
 				if (conf->conf_dolog)
@@ -2702,12 +2702,12 @@ mlfi_eom(SMFICTX *ctx)
 			}
 
 			*slash = '\0';
-			if ((strcasecmp(ar->ares_host, authservid) != 0 &&
+			if ((strcasecmp((char *)ar->ares_host, authservid) != 0 &&
 			     (conf->conf_trustedauthservids == NULL ||
-			      !dmarcf_match(ar->ares_host,
+			      !dmarcf_match((char *)ar->ares_host,
 			                    conf->conf_trustedauthservids,
 			                    FALSE))) ||
-			    strcmp(slash + 1, dfc->mctx_jobid) != 0)
+			    strcmp((char *)(slash + 1), dfc->mctx_jobid) != 0)
 			{
 				*slash = '/';
 
@@ -2753,18 +2753,18 @@ mlfi_eom(SMFICTX *ctx)
 				     i++)
 				{
 					if (ar->ares_result[c].result_ptype[i] == ARES_PTYPE_SMTP &&
-					    strcasecmp(ar->ares_result[c].result_property[i],
+					    strcasecmp((char *)ar->ares_result[c].result_property[i],
 					               "mailfrom") == 0)
 					{
 						char *d;
 
-						d = strchr(ar->ares_result[c].result_value[i],
+						d = strchr((char *)ar->ares_result[c].result_value[i],
 						           '@');
 						if (d == NULL)
-							d = ar->ares_result[c].result_value[i];
+							d = (char *)ar->ares_result[c].result_value[i];
 
 						if (strcasecmp(d,
-						               dfc->mctx_envdomain) == 0)
+						               (char *)dfc->mctx_envdomain) == 0)
 						{
 							envfrom_match = TRUE;
 							break;
@@ -2786,19 +2786,19 @@ mlfi_eom(SMFICTX *ctx)
 				{
 					if (ar->ares_result[c].result_ptype[pc] == ARES_PTYPE_SMTP)
 					{
-						if (strcasecmp(ar->ares_result[c].result_property[pc],
+						if (strcasecmp((char *)ar->ares_result[c].result_property[pc],
 					                       "mailfrom") == 0)
 						{
-							spfaddr = ar->ares_result[c].result_value[pc];
+							spfaddr = (char *)ar->ares_result[c].result_value[pc];
 							if (strchr(spfaddr, '@') != NULL)
 							{
-								strncpy(addrbuf,
+								strncpy((char *)addrbuf,
 								        spfaddr,
 								        sizeof addrbuf - 1);
 							}
 							else
 							{
-								snprintf(addrbuf,
+								snprintf((char *)addrbuf,
 								         sizeof addrbuf,
 								         "UNKNOWN@%s",
 								         spfaddr);
@@ -2806,12 +2806,12 @@ mlfi_eom(SMFICTX *ctx)
 
 							spfmode = DMARC_POLICY_SPF_ORIGIN_MAILFROM;
 						}
-						else if (strcasecmp(ar->ares_result[c].result_property[pc],
+						else if (strcasecmp((char *)ar->ares_result[c].result_property[pc],
 					                           "helo") == 0 &&
 						         addrbuf[0] == '\0')
 						{
-							spfaddr = ar->ares_result[c].result_value[pc];
-							snprintf(addrbuf,
+							spfaddr = (char *)ar->ares_result[c].result_value[pc];
+							snprintf((char *)addrbuf,
 							         sizeof addrbuf,
 							         "UNKNOWN@%s",
 							         spfaddr);
@@ -2975,7 +2975,7 @@ mlfi_eom(SMFICTX *ctx)
 
 					if (arcchain != NULL)
 					{
-						arcchainlen = dmarcf_mkarray(arcchain, ":",
+						arcchainlen = dmarcf_mkarray((char *)arcchain, ":",
 						                             &dfc->mctx_arcchain);
 						for (pc = 0;
 						     dfc->mctx_arcchain[pc] != NULL;
@@ -2984,7 +2984,7 @@ mlfi_eom(SMFICTX *ctx)
 							arcdomain = (u_char *)strdup(dfc->mctx_arcchain[pc]);
 							dmarcf_lowercase(arcdomain);
 
-							entry.key = arcdomain;
+							entry.key = (char *)arcdomain;
 							pthread_rwlock_rdlock(&hash_lock);
 							eptr = hsearch(entry,
 							               FIND);
@@ -3030,7 +3030,7 @@ mlfi_eom(SMFICTX *ctx)
 					spfmode = DMARC_POLICY_SPF_ORIGIN_MAILFROM;
 
 				spfres = dmarcf_parse_received_spf(hdr->hdr_value,
-				                                   dfc->mctx_envdomain);
+				                                   (char *)dfc->mctx_envdomain);
 
 				dfc->mctx_spfmode = spfmode;
 				dmarcf_dstring_printf(dfc->mctx_histbuf,
@@ -3108,7 +3108,7 @@ mlfi_eom(SMFICTX *ctx)
 				&used_mfrom);
 			if (used_mfrom == TRUE)
 			{
-				use_domain = dfc->mctx_envdomain;
+				use_domain = (char *)dfc->mctx_envdomain;
 				spf_mode   = DMARC_POLICY_SPF_ORIGIN_MAILFROM;
 			}
 			else
@@ -3118,10 +3118,10 @@ mlfi_eom(SMFICTX *ctx)
 			}
 			dfc->mctx_spfmode = spf_mode;
 			ostatus = opendmarc_policy_store_spf(cc->cctx_dmarc,
-				                             use_domain,
+				                             (u_char *)use_domain,
 				                             spf_result,
 				                             spf_mode,
-				                             human);
+				                             (u_char *)human);
 			switch (spf_result)
 			{
 			    case DMARC_POLICY_SPF_OUTCOME_PASS:
@@ -3152,19 +3152,19 @@ mlfi_eom(SMFICTX *ctx)
 
 			if (spf_mode == DMARC_POLICY_SPF_ORIGIN_HELO)
 			{
-				snprintf(header, MAXHEADER + 1,
+				snprintf((char *)header, MAXHEADER + 1,
 					 "%s; spf=%s smtp.helo=%s",
 					 authservid_hdr, pass_fail, use_domain);
 			}
 			else
 			{
-				snprintf(header, MAXHEADER + 1,
+				snprintf((char *)header, MAXHEADER + 1,
 					 "%s; spf=%s smtp.mailfrom=%s",
 					 authservid_hdr, pass_fail, use_domain);
 			}
 
 			if (dmarcf_insheader(ctx, 0, AUTHRESULTSHDR,
-					     header) == MI_FAILURE)
+					     (char *)header) == MI_FAILURE)
 			{
 				if (conf->conf_dolog)
 				{
@@ -3227,12 +3227,12 @@ mlfi_eom(SMFICTX *ctx)
 			       dfc->mctx_jobid, dfc->mctx_fromdomain, ostatus);
 		}
 
-		snprintf(header, MAXHEADER + 1,
+		snprintf((char *)header, MAXHEADER + 1,
 		         "%s; dmarc=permerror header.from=%s",
 		         authservid_hdr, dfc->mctx_fromdomain);
 
 		if (dmarcf_insheader(ctx, 0, AUTHRESULTSHDR,
-		                     header) == MI_FAILURE)
+		                     (char *)header) == MI_FAILURE)
 		{
 			if (conf->conf_dolog)
 			{
@@ -3367,14 +3367,14 @@ mlfi_eom(SMFICTX *ctx)
 		    random() % 100 < pct)
 		{
 			if (strstr(conf->conf_rejectstring, "%s") != NULL)
-				snprintf(replybuf, sizeof replybuf,
+				snprintf((char *)replybuf, sizeof replybuf,
 				         conf->conf_rejectstring, pdomain);
 			else
-				snprintf(replybuf, sizeof replybuf,
+				snprintf((char *)replybuf, sizeof replybuf,
 				         "%s", conf->conf_rejectstring);
 
 			status = dmarcf_setreply(ctx, DMARC_REJECT_SMTP,
-			                         DMARC_REJECT_ESC, replybuf);
+			                         DMARC_REJECT_ESC, (char *)replybuf);
 			if (status != MI_SUCCESS && conf->conf_dolog)
 			{
 				syslog(LOG_ERR, "%s: smfi_setreply() failed",
@@ -3466,11 +3466,11 @@ mlfi_eom(SMFICTX *ctx)
 
 	if (result == DMARC_RESULT_QUARANTINE)
 	{
-		snprintf(replybuf, sizeof replybuf,
+		snprintf((char *)replybuf, sizeof replybuf,
 		         "quarantined by DMARC policy for %s",
 		         pdomain);
 
-		status = smfi_quarantine(ctx, replybuf);
+		status = smfi_quarantine(ctx, (char *)replybuf);
 		if (status != MI_SUCCESS && conf->conf_dolog)
 		{
 			syslog(LOG_ERR, "%s: smfi_quarantine() failed",
@@ -3529,27 +3529,27 @@ mlfi_eom(SMFICTX *ctx)
 
 		for (c = 0; ruv != NULL && ruv[c] != NULL; c++)
 		{
-			if (strncasecmp(ruv[c], "mailto:", 7) != 0)
+			if (strncasecmp((char *)ruv[c], "mailto:", 7) != 0)
 				continue;
 
-			bang = strchr(ruv[c], '!');
+			bang = (u_char *)strchr((char *)ruv[c], '!');
 			if (bang != NULL)
 				*bang = '\0';
 
 			if (ruv[c][7] == '\0')
 				continue;
 
-			if (dmarcf_checkemail(&ruv[c][7], conf->conf_noreportslist))
+			if (dmarcf_checkemail((char *)&ruv[c][7], conf->conf_noreportslist))
 				continue;
 
 			if (first)
 			{
-				dmarcf_dstring_cat(dfc->mctx_afrf, "To: ");
+				dmarcf_dstring_cat(dfc->mctx_afrf, (u_char *)"To: ");
 				first = FALSE;
 			}
 			else
 			{
-				dmarcf_dstring_cat(dfc->mctx_afrf, ", ");
+				dmarcf_dstring_cat(dfc->mctx_afrf, (u_char *)", ");
 			}
 
 			dmarcf_dstring_cat(dfc->mctx_afrf, &ruv[c][7]);
@@ -3559,9 +3559,9 @@ mlfi_eom(SMFICTX *ctx)
 		{
 			if (first)
 			{
-				dmarcf_dstring_cat(dfc->mctx_afrf, "To: ");
+				dmarcf_dstring_cat(dfc->mctx_afrf, (u_char *)"To: ");
 				dmarcf_dstring_cat(dfc->mctx_afrf,
-				                   conf->conf_afrfbcc);
+				                   (u_char *)conf->conf_afrfbcc);
 				first = FALSE;
 			}
 		}
@@ -3575,15 +3575,15 @@ mlfi_eom(SMFICTX *ctx)
 			char timebuf[BUFRSZ];
 
 			/* finish To: from above */
-			dmarcf_dstring_cat(dfc->mctx_afrf, "\n");
+			dmarcf_dstring_cat(dfc->mctx_afrf, (u_char *)"\n");
 
 			/* Bcc: */
 			if (ruv != NULL && conf->conf_afrfbcc != NULL)
 			{
-				dmarcf_dstring_cat(dfc->mctx_afrf, "Bcc: ");
+				dmarcf_dstring_cat(dfc->mctx_afrf, (u_char *)"Bcc: ");
 				dmarcf_dstring_cat(dfc->mctx_afrf,
-				                   conf->conf_afrfbcc);
-				dmarcf_dstring_cat(dfc->mctx_afrf, "\n");
+				                   (u_char *)conf->conf_afrfbcc);
+				dmarcf_dstring_cat(dfc->mctx_afrf, (u_char *)"\n");
 			}
 
 			/* Date: */
@@ -3600,7 +3600,7 @@ mlfi_eom(SMFICTX *ctx)
 					      cc->cctx_host[0] != '\0' ? cc->cctx_host : cc->cctx_ipstr);
 
 			dmarcf_dstring_cat(dfc->mctx_afrf,
-			                   "MIME-Version: 1.0\n");
+			                   (u_char *)"MIME-Version: 1.0\n");
 
 			dmarcf_dstring_printf(dfc->mctx_afrf,
 			                      "Content-Type: multipart/report;"
@@ -3608,7 +3608,7 @@ mlfi_eom(SMFICTX *ctx)
 			                      "\n\tboundary=\"%s:%s\"\n",
 			                      hostname, dfc->mctx_jobid);
 
-			dmarcf_dstring_cat(dfc->mctx_afrf, "\n");
+			dmarcf_dstring_cat(dfc->mctx_afrf, (u_char *)"\n");
 
 			dmarcf_dstring_printf(dfc->mctx_afrf,
 			                      "--%s:%s\n"
@@ -3631,7 +3631,7 @@ mlfi_eom(SMFICTX *ctx)
 			                      hostname, dfc->mctx_jobid);
 
 			dmarcf_dstring_cat(dfc->mctx_afrf,
-			                   "Feedback-Type: auth-failure\n"
+			                   (u_char *)"Feedback-Type: auth-failure\n"
 			                   "Version: 1\n");
 
 			dmarcf_dstring_printf(dfc->mctx_afrf,
@@ -3639,7 +3639,7 @@ mlfi_eom(SMFICTX *ctx)
 			                      DMARCF_PRODUCTNS, DMARCF_VERSION);
 
 			dmarcf_dstring_cat(dfc->mctx_afrf,
-			                   "Auth-Failure: dmarc\n");
+			                   (u_char *)"Auth-Failure: dmarc\n");
 
 			dmarcf_dstring_printf(dfc->mctx_afrf,
 			                      "Authentication-Results: %s; dmarc=fail header.from=%s\n",
@@ -3662,22 +3662,22 @@ mlfi_eom(SMFICTX *ctx)
 			{
 			  case DMARC_RESULT_REJECT:
 				dmarcf_dstring_cat(dfc->mctx_afrf,
-				                   "Delivery-Result: reject\n");
+				                   (u_char *)"Delivery-Result: reject\n");
 				break;
 
 			  case DMARC_RESULT_QUARANTINE:
 				dmarcf_dstring_cat(dfc->mctx_afrf,
-				                   "Delivery-Result: policy\n");
+				                   (u_char *)"Delivery-Result: policy\n");
 				break;
 
 			  case DMARC_RESULT_TEMPFAIL:
 				dmarcf_dstring_cat(dfc->mctx_afrf,
-				                   "Delivery-Result: other\n");
+				                   (u_char *)"Delivery-Result: other\n");
 				break;
 
 			  default:
 				dmarcf_dstring_cat(dfc->mctx_afrf,
-				                   "Delivery-Result: delivered\n");
+				                   (u_char *)"Delivery-Result: delivered\n");
 				break;
 			}
 
@@ -3764,8 +3764,7 @@ mlfi_eom(SMFICTX *ctx)
 	}
 
 	/*
-/*
- 	**  Append arc override to historyfile.  The format 
+ 	**  Append arc override to historyfile.  The format
 	**
 	**  <reason>
 	**    <type>local_policy</type>
@@ -3849,14 +3848,14 @@ mlfi_eom(SMFICTX *ctx)
 	/* if the final action isn't TEMPFAIL or REJECT, add an A-R field */
 	if (ret != SMFIS_TEMPFAIL && ret != SMFIS_REJECT)
 	{
-		snprintf(header, MAXHEADER + 1,
+		snprintf((char *)header, MAXHEADER + 1,
 		         "%s; dmarc=%s (p=%s dis=%s) header.from=%s policy.dmarc=%s",
 		         authservid_hdr,
 		         aresult, apolicy, adisposition, dfc->mctx_fromdomain,
 		         apolicy);
 
 		if (dmarcf_insheader(ctx, 0, AUTHRESULTSHDR,
-		                     header) == MI_FAILURE)
+		                     (char *)header) == MI_FAILURE)
 		{
 			if (conf->conf_dolog)
 			{
@@ -3887,7 +3886,7 @@ mlfi_eom(SMFICTX *ctx)
 
 				memset(addrbuf, '\0', sizeof addrbuf);
 				strncpy((char *) addrbuf, val, sizeof addrbuf - 1);
-				status = dmarcf_mail_parse(addrbuf, &user, &domain);
+				status = dmarcf_mail_parse(addrbuf, (unsigned char **)&user, (unsigned char **)&domain);
 				if (status == 0 && user != NULL && domain != NULL)
 				{
 					snprintf((char *) replybuf, sizeof replybuf,
@@ -3976,14 +3975,14 @@ mlfi_eom(SMFICTX *ctx)
 	{
 		if (strcasecmp(hostname, myhostname) == 0)
 		{
-			snprintf(header, MAXHEADER + 1, "%s v%s %s %s",
+			snprintf((char *)header, MAXHEADER + 1, "%s v%s %s %s",
 			         DMARCF_PRODUCT, DMARCF_VERSION, hostname,
 			         dfc->mctx_jobid != NULL ? dfc->mctx_jobid
 			                                 : JOBIDUNKNOWN);
 		}
 		else
 		{
-			snprintf(header, MAXHEADER + 1, "%s v%s %s via %s %s",
+			snprintf((char *)header, MAXHEADER + 1, "%s v%s %s via %s %s",
 			         DMARCF_PRODUCT, DMARCF_VERSION, hostname,
 			         myhostname,
 			         dfc->mctx_jobid != NULL ? dfc->mctx_jobid
@@ -3991,7 +3990,7 @@ mlfi_eom(SMFICTX *ctx)
 		}
 
 		if (dmarcf_insheader(ctx, 0, SWHEADERNAME,
-		                     header) == MI_FAILURE)
+		                     (char *)header) == MI_FAILURE)
 		{
 			if (conf->conf_dolog)
 			{
@@ -5338,7 +5337,7 @@ main(int argc, char **argv)
 	if (curconf->conf_pslist != NULL)
 	{
 		libopendmarc.tld_type = OPENDMARC_TLD_TYPE_MOZILLA;
-		strncpy(libopendmarc.tld_source_file, curconf->conf_pslist,
+		strncpy((char *)libopendmarc.tld_source_file, curconf->conf_pslist,
 		        sizeof libopendmarc.tld_source_file - 1);
 	}
 

--- a/opendmarc/parse.c
+++ b/opendmarc/parse.c
@@ -517,8 +517,8 @@ dmarcf_mail_parse_multi(unsigned char *line, unsigned char ***users_out,
 	unsigned char *d;
 
 	/* walk the input string looking for unenclosed commas */
-	addr = line;
-	for (p = line; !done; p++)
+	addr = (char *)line;
+	for (p = (char *)line; !done; p++)
 	{
 		if (escaped)
 		{
@@ -556,7 +556,7 @@ dmarcf_mail_parse_multi(unsigned char *line, unsigned char ***users_out,
 			else
 				*p = '\0';
 
-			status = dmarcf_mail_parse(addr, &u, &d);
+			status = dmarcf_mail_parse((unsigned char *)addr, &u, &d);
 			if (status != 0)
 			{
 				if (uout != NULL)
@@ -617,8 +617,8 @@ dmarcf_mail_parse_multi(unsigned char *line, unsigned char ***users_out,
 			uout[n] = u;
 			dout[n++] = d;
 
-			uout[n] = (char *) NULL;
-			dout[n] = (char *) NULL;
+			uout[n] = (unsigned char *) NULL;
+			dout[n] = (unsigned char *) NULL;
 
 			addr = p + 1;
 


### PR DESCRIPTION
## Summary
- A non-CI build (clang on FreeBSD, no `-Wno-pointer-sign`) surfaced ~240 `-Wpointer-sign` warnings from the long-standing `char *`/`u_char *` mixing throughout libopendmarc and the milter, plus one stray nested-comment warning and one real `-Wincompatible-pointer-types` mismatch.
- Adds explicit casts at each char/u_char boundary rather than changing declared types, matching the existing style already used elsewhere in these files.
- Drops two backwards `(u_char *)` casts on `dfc->mctx_jobid`, which is actually declared `char *`.
- Removes a duplicate stray `/*` inside an already-open block comment in `opendmarc.c`.
- Fixes a genuine pointer-type mismatch in the `ignorereceivers` history path where locally-scoped `char *user`/`domain` were passed to a function expecting `unsigned char **`.

## Test plan
- [x] Full clean `make` rebuild (libopendmarc, opendmarc milter w/ libmilter + libspf2, reports) with default `CFLAGS` (no `-Wno-pointer-sign`): 0 warnings, 0 errors
- [x] `libopendmarc/tests`: `test_alignment`, `test_parse_to_buf`, `test_spf_parse` all pass
- [x] `opendmarc-check google.com` runs correctly end-to-end