### PR TITLE
fix: resolve char/u_char pointer-sign warnings in libopendmarc test suite

### DIFF
--- a/libopendmarc/tests/test_alignment.c
+++ b/libopendmarc/tests/test_alignment.c
@@ -47,7 +47,7 @@ main(int argc, char **argv)
 	for (alignp = alignm_test; alignp != NULL && alignp->subdomain != NULL; ++alignp)
 	{
 		count += 1;
-		outcome = opendmarc_policy_check_alignment(alignp->subdomain, alignp->tld, alignp->mode);
+		outcome = opendmarc_policy_check_alignment((u_char *)alignp->subdomain, (u_char *)alignp->tld, alignp->mode);
 		if (outcome == alignp->outcome)
 		{
 			//printf("\tALIGNMENT No TLD file: find test: %d: PASS\n", count);
@@ -71,7 +71,7 @@ main(int argc, char **argv)
 	for (alignp = alignm_test; alignp != NULL && alignp->subdomain != NULL; ++alignp)
 	{
 		count += 1;
-		outcome = opendmarc_policy_check_alignment(alignp->subdomain, alignp->tld, alignp->mode);
+		outcome = opendmarc_policy_check_alignment((u_char *)alignp->subdomain, (u_char *)alignp->tld, alignp->mode);
 		if (outcome == alignp->outcome)
 		{
 			//printf("\tALIGNMENT With TLD file: find test: %d: PASS\n", count);

--- a/libopendmarc/tests/test_dmarc_fetch.c
+++ b/libopendmarc/tests/test_dmarc_fetch.c
@@ -15,13 +15,13 @@ main(int argc, char **argv)
 	int aspf;
 	
 	pass = fails = count = 0;
-	pctx = opendmarc_policy_connect_init("1.2.3.4", 0);
+	pctx = opendmarc_policy_connect_init((u_char *)"1.2.3.4", 0);
 	if (pctx == NULL)
 	{
 		(void) fprintf(stderr, "opendmarc_policy_connect_init: %s\n", strerror(errno));
 		return 1;
 	}
-	status = opendmarc_policy_parse_dmarc(pctx, "abuse.net", record);
+	status = opendmarc_policy_parse_dmarc(pctx, (u_char *)"abuse.net", (u_char *)record);
 	if (status != DMARC_PARSE_OKAY)
 	{
 		printf("\t%s(%d): opendmarc_policy_parse_dmarc: %s: FAIL\n", __FILE__, __LINE__, opendmarc_policy_status_to_str(status));
@@ -85,7 +85,7 @@ main(int argc, char **argv)
 	count++;
 	{
 		u_char buf[256];
-		u_char *ret = opendmarc_policy_fetch_ruf(pctx, buf, sizeof buf, 1);
+		u_char **ret = opendmarc_policy_fetch_ruf(pctx, buf, sizeof buf, 1);
 		if (ret == NULL)
 		{
 			printf("\t%s(%d): fetch_ruf with valid buf returned NULL: FAIL\n", __FILE__, __LINE__);
@@ -107,7 +107,7 @@ main(int argc, char **argv)
 	count++;
 	{
 		u_char buf[256];
-		u_char *ret = opendmarc_policy_fetch_rua(pctx, buf, sizeof buf, 1);
+		u_char **ret = opendmarc_policy_fetch_rua(pctx, buf, sizeof buf, 1);
 		if (ret == NULL)
 		{
 			printf("\t%s(%d): fetch_rua with valid buf returned NULL: FAIL\n", __FILE__, __LINE__);

--- a/libopendmarc/tests/test_dmarc_parse.c
+++ b/libopendmarc/tests/test_dmarc_parse.c
@@ -45,13 +45,13 @@ main(int argc, char **argv)
 	for (dpp = dpp_test; dpp != NULL && dpp->dmarc != NULL; ++dpp)
 	{
 		count += 1;
-		pctx = opendmarc_policy_connect_init("1.2.3.4", 0);
+		pctx = opendmarc_policy_connect_init((u_char *)"1.2.3.4", 0);
 		if (pctx == NULL)
 		{
 			(void) fprintf(stderr, "opendmarc_policy_connect_init: %s\n", strerror(errno));
 			return 1;
 		}
-		status = opendmarc_policy_parse_dmarc(pctx, "abuse.net", dpp->dmarc);
+		status = opendmarc_policy_parse_dmarc(pctx, (u_char *)"abuse.net", (u_char *)dpp->dmarc);
 		if (status == dpp->outcome)
 		{
 			//printf("\tDMARC Policy Parse: %d: PASS\n", count);

--- a/libopendmarc/tests/test_finddomain.c
+++ b/libopendmarc/tests/test_finddomain.c
@@ -35,14 +35,14 @@ main(int argc, char **argv)
 	for (domp = domain_test; domp != NULL && domp->raw != NULL; ++domp)
 	{
 		count += 1;
-		dp = opendmarc_util_finddomain(domp->raw, dbuf, sizeof dbuf);
+		dp = opendmarc_util_finddomain((u_char *)domp->raw, dbuf, sizeof dbuf);
 		if (dp == NULL)
 		{
 			(void) printf("\t%s: %s\n", domp->raw, strerror(errno));
 			++fails;
 			continue;
 		}
-		if (strcmp(dbuf, domp->should_get) == 0)
+		if (strcmp((char *)dbuf, domp->should_get) == 0)
 		{
 			//printf("\tFinddomain test: %d: PASS\n", count);
 			pass += 1;

--- a/libopendmarc/tests/test_parse_to_buf.c
+++ b/libopendmarc/tests/test_parse_to_buf.c
@@ -15,13 +15,13 @@ main(int argc, char **argv)
 	char	big_buf[BUFSIZ * 4];
 	
 	pass = fails = count = 0;
-	pctx = opendmarc_policy_connect_init("1.2.3.4", 0);
+	pctx = opendmarc_policy_connect_init((u_char *)"1.2.3.4", 0);
 	if (pctx == NULL)
 	{
 		(void) fprintf(stderr, "opendmarc_policy_connect_init: %s\n", strerror(errno));
 		return 1;
 	}
-	status = opendmarc_policy_parse_dmarc(pctx, "abuse.net", record);
+	status = opendmarc_policy_parse_dmarc(pctx, (u_char *)"abuse.net", (u_char *)record);
 	if (status == DMARC_PARSE_OKAY)
 	{
 		pass += 1;

--- a/libopendmarc/tests/test_tld.c
+++ b/libopendmarc/tests/test_tld.c
@@ -30,7 +30,7 @@ main(int argc, char **argv)
 	for (tldp = tld_test; tldp != NULL && tldp->domain != NULL; ++tldp)
 	{
 		count += 1;
-		(void) opendmarc_get_tld(tldp->domain, tldbuf, sizeof tldbuf);
+		(void) opendmarc_get_tld((u_char *)tldp->domain, tldbuf, sizeof tldbuf);
 		if (memcmp(tldp->tld, tldbuf, strlen(tldp->tld)) == 0)
 		{
 			//printf("\tTLD find test: %d: PASS\n", count);


### PR DESCRIPTION
## Summary
Follow-up to #426. \`make all\` doesn't build \`libopendmarc/tests/\`, so \`make check\` surfaces its own set of \`-Wpointer-sign\` warnings once libmilter/libspf2 are on the include path. Same cast-based fix applied to 6 test files.

Also fixes a genuine bug caught by \`-Wincompatible-pointer-types\`: \`test_dmarc_fetch.c\` declared the return of \`opendmarc_policy_fetch_ruf\`/\`opendmarc_policy_fetch_rua\` as \`u_char *\`, but both functions actually return \`u_char **\`.

## Test plan
- [x] \`make check\`: 0 warnings, 0 errors, all 11 test programs pass
- [x] Full \`make\` rebuild still clean (re-verified after rebasing onto current develop)