### PR TITLE
fix: quiet -Walloc-size-larger-than and -Wformat-truncation warnings

### DIFF
--- a/libopendmarc/opendmarc_internal.h
+++ b/libopendmarc/opendmarc_internal.h
@@ -209,10 +209,15 @@ typedef struct {
 #define	OPENDMARC_MIN_SHELVES	(1 << OPENDMARC_MIN_SHELVES_LG2)
 
 /*
- * max * sizeof internal_entry must fit into size_t.
- * assumes internal_entry is <= 32 (2^5) bytes.
+ * Largest table size opendmarc_hash_init() will honor. The real
+ * caller (opendmarc_tld.c) only ever asks for 8192; this just keeps a
+ * runaway or hostile tablesize argument from reaching calloc(). Fixed
+ * well below any allocator limit rather than derived from sizeof(size_t),
+ * since the size of OPENDMARC_HASH_SHELF (which includes a pthread_mutex_t)
+ * varies by platform and a sizeof-derived bound can creep past what
+ * calloc() will actually allocate.
  */
-#define	OPENDMARC_MAX_SHELVES_LG2	(sizeof (size_t) * 8 - 1 - 5)
+#define	OPENDMARC_MAX_SHELVES_LG2	24
 #define	OPENDMARC_MAX_SHELVES	((size_t)1 << OPENDMARC_MAX_SHELVES_LG2)
 
 typedef struct {

--- a/libopendmarc/tests/Makefile.am
+++ b/libopendmarc/tests/Makefile.am
@@ -1,3 +1,4 @@
+AUTOMAKE_OPTIONS = subdir-objects
 SUBDIRS=testfiles
 LDADD = ../libopendmarc.la $(LIBRESOLV)
 AM_CPPFLAGS = -I.. -I../..

--- a/opendmarc/opendmarc.h
+++ b/opendmarc/opendmarc.h
@@ -37,7 +37,7 @@
 #define	REPORTCMD_EXIT_SUPPRESSED	2	/* ReportCommand sent nothing; all recipients were suppressed by policy (e.g. NoReportsList/StaleMARC), not an error */
 #define	JOBIDUNKNOWN	"(unknown-jobid)"
 #define	MAXARGV		65536
-#define	MAXHEADER	4096
+#define	MAXHEADER	8192
 #define	TEMPFILE	"/var/tmp/dmarcXXXXXX"
 
 #define AUTHRESULTSHDR	"Authentication-Results"


### PR DESCRIPTION
## Summary
- `OPENDMARC_MAX_SHELVES_LG2` was derived from `sizeof(size_t)` assuming `OPENDMARC_HASH_SHELF` is <= 32 bytes, but it holds a `pthread_mutex_t` and actually runs 48-72 bytes depending on platform, so the theoretical max `calloc()` request in `opendmarc_hash_init()` could exceed the allocator limit (`-Walloc-size-larger-than=`). The only real caller asks for 8192 buckets, so cap the table size at a fixed, generous bound (16M) instead.
- `MAXHEADER` (4096) was small enough that a maxed-out `authservid_hdr` plus a maxed-out From-domain could together exceed the malloc'd header buffer in `opendmarc.c`, risking silent truncation of the `Authentication-Results` header in pathological cases (`-Wformat-truncation=`). Doubled to 8192 so the worst case fits.

Both warnings are pre-existing on `develop` and not specific to any in-flight feature branch; confirmed via the CI logs on PR #435.

## Test plan
- [x] `make` in `libopendmarc/` and `opendmarc/` succeeds locally (clang)
- [ ] CI (Linux/gcc) no longer emits `-Walloc-size-larger-than=` or `-Wformat-truncation=` for these two spots