### PR TITLE
feat: always log StaleMARC/suppressions-DB report skips

### DIFF
--- a/reports/opendmarc-reports.8.in
+++ b/reports/opendmarc-reports.8.in
@@ -302,12 +302,26 @@ Print version number and exit.
 The script checks the
 .I suppressions
 database table before sending each report.  If the destination RUA/RUF
-address, or its domain, appears in that table the report is silently
-skipped.  The table is also checked at the domain level, so adding a bare
-domain name (e.g.
+address, or its domain, appears in that table the report is skipped.  The
+table is also checked at the domain level, so adding a bare domain name
+(e.g.
 .IR example.com )
 suppresses all reports for that domain regardless of their destination
 address.  Applies to both aggregate and forensic modes.
+.PP
+Skips caused by the suppressions table or by
+.I --stale-check
+are always written to standard error, even without
+.IR --verbose ,
+since these come from dynamic or external sources the operator may not be
+expecting.  Skips caused by
+.B NoReportsList
+or
+.I --skipdomains
+are not, since those are operator-curated and the operator already knows
+what they contain; pass
+.I --verbose
+to see those as well.
 .PP
 The table is loaded once at startup and is not queried per-message, so
 changes take effect on the next run.  If the table does not exist (e.g. on

--- a/reports/opendmarc-reports.in
+++ b/reports/opendmarc-reports.in
@@ -263,6 +263,18 @@ sub noreports_skip
 	return 0;
 }
 
+# StaleMARC and the suppressions DB are dynamic/external sources that can
+# silently drop reports the operator wasn't expecting, so skips they cause
+# are always worth printing.  NoReportsList is operator-curated -- the
+# operator already knows what's in it -- so it stays --verbose-only to
+# avoid flooding output when it's used heavily.
+sub loud_skip
+{
+	my ($reason) = @_;
+
+	return $reason eq "StaleMARC" || $reason eq "suppression DB";
+}
+
 # Returns the reason a destination address should be skipped (for logging),
 # or undef if it should be sent to.  Combines every suppression source so
 # the result -- and therefore the recipients who actually get mail -- is
@@ -688,7 +700,7 @@ if ($forensic)
 		if (defined($reason))
 		{
 			print STDERR "$progname: --forensic: skipping report for $reported_domain ($reason)\n"
-				if $verbose;
+				if $verbose || loud_skip($reason);
 			exit($EXIT_SUPPRESSED);
 		}
 	}
@@ -728,7 +740,7 @@ if ($forensic)
 	@rcpts = grep {
 		my $reason = skip_reason($_);
 		print STDERR "$progname: --forensic: skipping $_ ($reason)\n"
-			if defined($reason) && $verbose;
+			if defined($reason) && ($verbose || loud_skip($reason));
 		!defined($reason);
 	} @rcpts;
 
@@ -1035,7 +1047,8 @@ foreach (@$domainset)
 	my $domain_reason = domain_skip_reason($domain);
 	if (defined($domain_reason))
 	{
-		print STDERR "$progname: skipping $domain ($domain_reason)\n" if $verbose;
+		print STDERR "$progname: skipping $domain ($domain_reason)\n"
+			if $verbose || loud_skip($domain_reason);
 		next;
 	}
 
@@ -1632,7 +1645,7 @@ foreach (@$domainset)
 			if (defined($reason))
 			{
 				print STDERR "$progname: skipping $domain report to $repdest ($reason)\n"
-					if $verbose;
+					if $verbose || loud_skip($reason);
 				next;
 			}
 		}


### PR DESCRIPTION
## Summary
- Every report-skip reason (StaleMARC, the suppressions DB, NoReportsList/--skipdomains) was previously only printed under `--verbose`, so a report silently dropped via StaleMARC or the suppressions table left no trace in a normal cron run.
- Adds a `loud_skip()` helper and wires it into all four skip print sites (aggregate domain-level, aggregate recipient-level, and both `--forensic` equivalents): StaleMARC and suppressions-DB skips are now always written to stderr, regardless of `--verbose`.
- `NoReportsList`/`--skipdomains` skips remain `--verbose`-only, since that list is operator-curated and the operator already knows what's in it; making those loud too would just be noise for anyone using it heavily.
- Documents the new behavior in the `REPORTING SUPPRESSIONS` section of the man page.

## Test plan
- [x] `perl -c` on all report scripts (generated from `.in` templates) — syntax OK
- [x] Standalone check that `loud_skip()` returns true only for "StaleMARC"/"suppression DB" and false for both NoReportsList variants
- [x] Man page renders correctly via `mandoc`